### PR TITLE
Add ability for separate topic and subscription GCP projects

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ grpcio = "*"
 structlog = "*"
 "jinja2" = "*"
 "tonyg-rfc3339" = "*"
+pika = "*"
 
 [dev-packages]
 codecov = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1a7ca4db6e2f98889bc498186590b8d5dbceb7c629a710c4e37c29ec23be300a"
+            "sha256": "051318bc43e3db787aca0df2d6afc8758ab286a38f95e28139a4f47a510e5acb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -158,6 +158,14 @@
                 "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
             "version": "==1.1.0"
+        },
+        "pika": {
+            "hashes": [
+                "sha256:5338d829d1edb3e5bcf1523b4a9e32c56dea5a8bda7018825849e35325580484",
+                "sha256:847916ada527ee064025c1a0b981dc6856ea333734e695012006c24cab233bca"
+            ],
+            "index": "pypi",
+            "version": "==0.13.0"
         },
         "protobuf": {
             "hashes": [
@@ -350,11 +358,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
-                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
-                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==5.0.0"
+            "version": "==6.0.0"
         },
         "pluggy": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -6,33 +6,35 @@
 
 * A GCS bucket with a [Cloud Pub/Sub notification configuration](https://cloud.google.com/storage/docs/reporting-changes):
 	```bash
+	gsutil mb -c regional -l europe-west2 -p [RECEIPT_TOPIC_PROJECT_ID] gs://[BUCKET_NAME]
 	gsutil notification create -t [TOPIC_NAME] -f json gs://[BUCKET_NAME]
 	```
 
 * Relevant environment variables:
 	```bash
-	RABBIT_AMQP=[RABBIT_URL]
-	GCP_PROJECT_ID=[PROJECT_ID]
-	RABBIT_QUEUE=[QUEUE_BINDING_ID]
-	RABBIT_EXCHANGE=[EXCHANGE_ID]
-	EQ_TOPIC_NAME=[TOPIC_NAME]
+	GOOGLE_APPLICATION_CREDENTIALS
+	LOG_LEVEL	
+	RABBIT_AMQP
+	RABBIT_QUEUE
+	RABBIT_EXCHANGE	
+	RECEIPT_TOPIC_NAME
+	RECEIPT_TOPIC_PROJECT_ID
+	SUBSCRIPTION_NAME
+	SUBSCRIPTION_PROJECT_ID
 	```
 
 * [Pipenv](https://docs.pipenv.org/index.html) for local development.
 
 ## To test receipting against RM (dev)
 
-* Start RM services in Docker: 
+* Start RM services in Docker:
 ```bash
 git clone git@github.com:ONSdigital/ras-rm-docker-dev.git
-pushd ras-rm-docker-dev
-make up
-popd
+cd ras-rm-docker-dev && make up
 ```
 
 * POST to rm-sdx-gateway endpoint to create rabbitmq bindings: 
 ```bash
-
 curl -X POST \
   http://0.0.0.0:8191/receipts \
   -H 'Content-Type: application/json' \
@@ -60,11 +62,13 @@ export PUBSUB_EMULATOR_HOST=::1:8410
 ```bash
 cat > .env << EOS
 RABBIT_AMQP=amqp://guest:guest@localhost:6672
-GCP_PROJECT_ID=project
+SUBSCRIPTION_PROJECT_ID=project
+RECEIPT_TOPIC_PROJECT_ID=project
 PUBSUB_EMULATOR_HOST=localhost:8410
 RABBIT_QUEUE=Case.Responses.binding
 RABBIT_EXCHANGE=case-outbound-exchange
-EQ_TOPIC_NAME=eq-submission-topic
+RECEIPT_TOPIC_NAME=eq-submission-topic
+SUBSCRIPTION_NAME=rm-receipt-subscription
 EOS
 ```
 
@@ -73,7 +77,7 @@ EOS
 pipenv install
 pipenv shell
 
-python test/create_topic.py $GCP_PROJECT_ID $EQ_TOPIC_NAME
+python test/create_topic.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
 python run.py
 ```
 
@@ -84,5 +88,5 @@ docker logs casesvc -f
 
 * In a separate terminal, publish a message to the Pub/Sub emulator:
 ```bash
-pipenv run python test/publish_message.py $GCP_PROJECT_ID $EQ_TOPIC_NAME
+pipenv run python test/publish_message.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
 ```

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ export PUBSUB_EMULATOR_HOST=::1:8410
 * Create .env file in census-rm-pubsub directory:
 ```bash
 cat > .env << EOS
-RABBIT_AMQP=amqp://guest:guest@localhost:6672
-SUBSCRIPTION_PROJECT_ID=project
-RECEIPT_TOPIC_PROJECT_ID=project
-PUBSUB_EMULATOR_HOST=localhost:8410
+RABBIT_AMQP=amqp://guest:guest@localhost:6672  # taken from ras-rm-docker-dev
+SUBSCRIPTION_PROJECT_ID=project  # can be anything
+RECEIPT_TOPIC_PROJECT_ID=project  # can be anything
+PUBSUB_EMULATOR_HOST=localhost:8410  # taken from the env-init (above)
 RABBIT_QUEUE=Case.Responses.binding
 RABBIT_EXCHANGE=case-outbound-exchange
 RECEIPT_TOPIC_NAME=eq-submission-topic

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -13,9 +13,10 @@ from structlog import wrap_logger
 from app.rabbit_helper import send_message_to_rabbitmq
 
 
-GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID")
-EQ_TOPIC_NAME = os.getenv("GCP_TOPIC_NAME", "eq-submission-topic")
-RM_SUBSCRIPTION_NAME = os.getenv("GCP_SUBSCRIPTION_NAME", "rm-receipt-subscription")
+RECEIPT_TOPIC_NAME = os.getenv("RECEIPT_TOPIC_NAME", "eq-submission-topic")
+RECEIPT_TOPIC_PROJECT_ID = os.getenv("RECEIPT_TOPIC_PROJECT_ID")
+SUBSCRIPTION_NAME = os.getenv("SUBSCRIPTION_NAME", "rm-receipt-subscription")
+SUBSCRIPTION_PROJECT_ID = os.getenv("SUBSCRIPTION_PROJECT_ID")
 
 logger = wrap_logger(logging.getLogger(__name__))
 client = SubscriberClient()
@@ -52,28 +53,30 @@ def receipt_to_case(message: Message):
     message.ack()
 
 
-def setup_subscription(project_id=GCP_PROJECT_ID,
-                       subscription_name=RM_SUBSCRIPTION_NAME,
-                       topic_name=EQ_TOPIC_NAME,
+def setup_subscription(subscription_name=SUBSCRIPTION_NAME,
+                       subscription_project_id=SUBSCRIPTION_PROJECT_ID,
+                       topic_name=RECEIPT_TOPIC_NAME,
+                       topic_project_id=RECEIPT_TOPIC_PROJECT_ID,
                        callback=receipt_to_case):
     """
     Create (it not exists) a new pubsub subscription in GCP to a pubsub topic
     and a subscriber thread which handles new messages through a callback
 
-    :param project_id: GCP project identifier
     :param subscription_name: The name of the pubsub subscription
+    :param subscription_project_id: GCP project where subscription should exist
     :param topic_name: The pubsub topic to subscribe to
+    :param topic_project_id: GCP project where topic should exist
     :param callback: The callback to use upon receipt of a new message from the subscription
     :return: a StreamingPullFuture for managing the callback thread
     """
-    topic_path = client.topic_path(project_id, topic_name)
-    subscription_path = client.subscription_path(project_id, subscription_name)
+    topic_path = client.topic_path(topic_project_id, topic_name)
+    subscription_path = client.subscription_path(subscription_project_id, subscription_name)
     try:
         client.create_subscription(subscription_path, topic_path)
     except AlreadyExists:
         logger.info('Subscription already exists', subscription_path=subscription_path, topic_path=topic_path)
     except PermissionDenied:
-        logger.warn('Subscription can not be created')
+        logger.exception('Subscription can not be created')
     else:
         logger.info('Subscription created', subscription_path=subscription_path, topic_path=topic_path)
     subscriber_future = client.subscribe(subscription_path, callback)


### PR DESCRIPTION
### Motivation and Context
Long term intention is for this to listen on a Pub/Sub Subscription created within RM's GCP Project which is a subscriber of a Pub/Sub Topic within EQ's GCP Project.

### What Has Changed
- Changed and added environment variables for separate projects
- Updated [README](https://github.com/ONSdigital/census-rm-pubsub/blob/split-topic-sub-projects/README.md)

### Links
https://trello.com/c/R8IqnZzQ
