### PR TITLE
Add Travis YML to build and push docker images to GCR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+## How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+## Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - pipenv check
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if ([ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_PULL_REQUEST_BRANCH" == "add-travis-build-yml" ]); then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker push "$DESTINATION_IMAGE_NAME";

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+services:
+  - docker
+
+language: python
+
+python:
+  - "3.6"
+
+install:
+  - pip install pipenv
+  - pipenv install --dev --deploy
+  - pipenv check
+
+after_success:
+- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker build -t "$DESTINATION_IMAGE_NAME" .;
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker push "$DESTINATION_IMAGE_NAME";
+  fi
+- bash <(curl -s https://codecov.io/bash)
+
+env:
+  global:
+    - PIPENV_IGNORE_VIRTUALENVS=1
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-pubsub"
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ after_success:
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker push "$DESTINATION_IMAGE_NAME";
   fi
-- bash <(curl -s https://codecov.io/bash)
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - pipenv check
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_PULL_REQUEST_BRANCH" == "add-travis-build-yml" ]); then
+- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker push "$DESTINATION_IMAGE_NAME";

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ python:
 install:
   - pip install pipenv
   - pipenv install --dev --deploy
+
+script:
   - pipenv check
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# census-rm-pubsub [![Build Status](https://travis-ci.com/ONSdigital/census-rm-pubsub.svg?branch=master)](https://travis-ci.com/ONSdigital/census-rm-pubsub)
+# census-rm-pubsub 
+[![Build Status](https://travis-ci.com/ONSdigital/census-rm-pubsub.svg?branch=master)](https://travis-ci.com/ONSdigital/census-rm-pubsub)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# census-rm-pubsub
+# census-rm-pubsub [![Build Status](https://travis-ci.com/ONSdigital/census-rm-pubsub.svg?branch=master)](https://travis-ci.com/ONSdigital/census-rm-pubsub)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Motivation and Context
We need travis builds to build docker images off of master and push them to our GCR. Also runs `pipenv check` which can block PR's on unsafe package versions.

## What has changed
- Add travis build yml
- Add travis master build status to README
- Add github PR template

## How to test?
Check the travis build for this repo. Pushing to docker was temporarily enabled for this branch as well as master so you should also see the docker image pushed by the build in GCR.

## Links
https://trello.com/c/UDZtgxSZ/483-deploy-census-rm-pubsub-to-kubernetes-8