### PR TITLE
Create rabbit bindings on startup if they don't yet exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,6 @@ docker logs casesvc -f
 
 * In a separate terminal, publish a message to the Pub/Sub emulator:
 ```bash
-pipenv run python test/publish_message.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
+pipenv shell
+python test/publish_message.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	RABBIT_AMQP
 	RABBIT_QUEUE
 	RABBIT_EXCHANGE
+	RABBIT_ROUTE
 	RECEIPT_TOPIC_NAME
 	RECEIPT_TOPIC_PROJECT_ID
 	SUBSCRIPTION_NAME
@@ -40,15 +41,6 @@ git clone git@github.com:ONSdigital/ras-rm-docker-dev.git
 cd ras-rm-docker-dev && make up
 ```
 
-* POST to rm-sdx-gateway endpoint to create rabbitmq bindings:
-```bash
-curl -X POST \
-  http://0.0.0.0:8191/receipts \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Basic YWRtaW46c2VjcmV0' \
-  -d '{"caseId": "e72b8990-960a-4be3-b14c-06600e38ee3d", "userId": "3b744811-07a4-4118-8022-29c922363fb2"}'
-```
-
 * Create `.env` file in census-rm-pubsub directory:
 ```bash
 cat > .env << EOS
@@ -56,8 +48,9 @@ RABBIT_AMQP=amqp://guest:guest@localhost:6672
 SUBSCRIPTION_PROJECT_ID=[SUB_PROJECT_ID]
 RECEIPT_TOPIC_PROJECT_ID=[RECEIPT_TOPIC_PROJECT_ID]
 GOOGLE_APPLICATION_CREDENTIALS=[/path/to/service/account/key.json]
-RABBIT_QUEUE=Case.Responses.binding
+RABBIT_QUEUE=Case.Responses
 RABBIT_EXCHANGE=case-outbound-exchange
+RABBIT_ROUTE=Case.Responses.binding
 RECEIPT_TOPIC_NAME=[TOPIC_NAME]
 SUBSCRIPTION_NAME=[NEW_OR_EXISTING_SUB_NAME]
 EOS
@@ -78,15 +71,6 @@ git clone git@github.com:ONSdigital/ras-rm-docker-dev.git
 cd ras-rm-docker-dev && make up
 ```
 
-* POST to rm-sdx-gateway endpoint to create rabbitmq bindings: 
-```bash
-curl -X POST \
-  http://0.0.0.0:8191/receipts \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Basic YWRtaW46c2VjcmV0' \
-  -d '{"caseId": "e72b8990-960a-4be3-b14c-06600e38ee3d", "userId": "3b744811-07a4-4118-8022-29c922363fb2"}'
-```
-
 * Start Cloud Pub/Sub emulator:
 ```bash
 gcloud components install pubsub-emulator
@@ -103,15 +87,16 @@ example output:
 export PUBSUB_EMULATOR_HOST=::1:8410
 ```
 
-* Create .env file in census-rm-pubsub directory:
+* Create `.env` file in census-rm-pubsub directory:
 ```bash
 cat > .env << EOS
 RABBIT_AMQP=amqp://guest:guest@localhost:6672  # taken from ras-rm-docker-dev
 SUBSCRIPTION_PROJECT_ID=project  # can be anything
 RECEIPT_TOPIC_PROJECT_ID=project  # can be anything
 PUBSUB_EMULATOR_HOST=localhost:8410  # taken from the env-init (above)
-RABBIT_QUEUE=Case.Responses.binding
+RABBIT_QUEUE=Case.Responses
 RABBIT_EXCHANGE=case-outbound-exchange
+RABBIT_ROUTE=Case.Responses.binding
 RECEIPT_TOPIC_NAME=eq-submission-topic
 SUBSCRIPTION_NAME=rm-receipt-subscription
 EOS

--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -10,6 +10,9 @@ RM_RABBIT_EXCHANGE = os.getenv("RABBIT_EXCHANGE", "case-outbound-exchange")
 RM_RABBIT_QUEUE = os.getenv("RABBIT_QUEUE", "Case.Responses")
 RM_RABBIT_ROUTE = os.getenv("RABBIT_ROUTING_KEY", "Case.Responses.binding")
 
+RM_RABBIT_QUEUE_ARGS = {'x-dead-letter-exchange': 'case-deadletter-exchange',
+                        'x-dead-letter-routing-key': RM_RABBIT_ROUTE}
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -28,8 +31,8 @@ def init_rabbitmq(rabbitmq_amqp=RM_RABBIT_AMQP,
     logger.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
     channel = rabbitmq_connection.channel()
-    channel.exchange_declare(exchange=exchange_name, exchange_type='direct')
-    channel.queue_declare(queue=queue_name, durable=True)
+    channel.exchange_declare(exchange=exchange_name, exchange_type='direct', durable=True)
+    channel.queue_declare(queue=queue_name, durable=True, arguments=RM_RABBIT_QUEUE_ARGS)
     channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=binding_key)
     logger.info('Successfully initialised rabbitmq', exchange=exchange_name, binding=binding_key)
 

--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -7,40 +7,53 @@ from structlog import wrap_logger
 
 RM_RABBIT_AMQP = os.getenv("RABBIT_AMQP", "amqp://guest:guest@localhost:6672")
 RM_RABBIT_EXCHANGE = os.getenv("RABBIT_EXCHANGE", "case-outbound-exchange")
-RM_RABBIT_QUEUE = os.getenv("RABBIT_QUEUE", "Case.Responses.binding")
+RM_RABBIT_QUEUE = os.getenv("RABBIT_QUEUE", "Case.Responses")
+RM_RABBIT_ROUTE = os.getenv("RABBIT_ROUTING_KEY", "Case.Responses.binding")
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def init_rabbitmq(rabbitmq_amqp=RM_RABBIT_AMQP, queue_name=RM_RABBIT_QUEUE):
+def init_rabbitmq(rabbitmq_amqp=RM_RABBIT_AMQP,
+                  binding_key=RM_RABBIT_ROUTE,
+                  exchange_name=RM_RABBIT_EXCHANGE,
+                  queue_name=RM_RABBIT_QUEUE):
     """
     Initialise connection to rabbitmq
 
-    :param rabbitmq_amqp: The amqp (url) of the rabbit queue
-    :param queue_name: The rabbit queue to publish to
+    :param rabbitmq_amqp: The amqp (url) of the rabbitmq connection
+    :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "case-outbound-exchange")
+    :param queue_name: The rabbitmq queue that subscribes to the exchange, (e.g.: "Case.Responses")
+    :param binding_key: The binding key to associate the exchange and queue (e.g.: "Case.Responses.binding")
     """
     logger.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
-    _ = rabbitmq_connection.channel()
-    logger.info('Successfully initialised rabbitmq', queue=queue_name)
+    channel = rabbitmq_connection.channel()
+    channel.exchange_declare(exchange=exchange_name, exchange_type='direct')
+    channel.queue_declare(queue=queue_name, durable=True)
+    channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=binding_key)
+    logger.info('Successfully initialised rabbitmq', exchange=exchange_name, binding=binding_key)
 
 
-def send_message_to_rabbitmq(message, rabbitmq_amqp=RM_RABBIT_AMQP, queue_name=RM_RABBIT_QUEUE):
+def send_message_to_rabbitmq(message,
+                             rabbitmq_amqp=RM_RABBIT_AMQP,
+                             exchange_name=RM_RABBIT_EXCHANGE,
+                             routing_key=RM_RABBIT_ROUTE):
     """
     Send message to rabbitmq
 
     :param message: The message to send to the queue in JSON format
-    :param rabbitmq_amqp: The amqp (url) of the rabbit queue
-    :param queue_name: The rabbit queue to publish to
+    :param rabbitmq_amqp: The amqp (url) of the rabbitmq connection
+    :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "case-outbound-exchange")
+    :param routing_key: The direct route to a queue the message should be sent to (e.g.: "Case.Responses.binding")
     :return: boolean
     :raises: PublishMessageError
     """
     logger.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
     rabbitmq_channel = rabbitmq_connection.channel()
-    rabbitmq_channel.basic_publish(exchange=RM_RABBIT_EXCHANGE,
-                                   routing_key=queue_name,
+    rabbitmq_channel.basic_publish(exchange=exchange_name,
+                                   routing_key=routing_key,
                                    body=str(message),
                                    properties=pika.BasicProperties(content_type='text/xml'))
-    logger.info('Message successfully sent to rabbitmq', queue=queue_name)
+    logger.info('Message successfully sent to rabbitmq', exchange=exchange_name, route=routing_key)
     rabbitmq_connection.close()


### PR DESCRIPTION
## Motivation and Context
Without rm-sdx-gateway present as a service, we need to initialise the relevant rabbitmq exchange and binding to a queue rather than assume they already exist.

NB: matches [definitions in case service](https://github.com/ONSdigital/rm-case-service/blob/3351987d07795378a0bcca43a22125691b7b4700/src/main/resources/springintegration/broker.xml#L22).

## What has changed
- Add new environment variable for binding/routing name
- Add rabbitmq declarations at startup
- Remove gateway "hack" from README

## How to test?
Follow README.

## Links
https://trello.com/c/v3VlIAnX