### PR TITLE
Remove functionality for creating a pubsub sub from setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
 
 * Create a GCS bucket with a Cloud Pub/Sub notification configuration:
 ```bash
-gsutil mb -c regional -l europe-west2 -p [RECEIPT_TOPIC_PROJECT_ID] gs://[BUCKET_NAME]
+gsutil mb -c regional -l europe-west2 -p [TOPIC_PROJECT_ID] gs://[BUCKET_NAME]
 gsutil notification create -t [TOPIC_NAME] -f json gs://[BUCKET_NAME]
+gcloud beta pubsub subscriptions create --topic [TOPIC_NAME] [SUBSCRIPTION_NAME]
 ```
 
 * Start RM services in Docker:
@@ -47,13 +48,13 @@ cd ras-rm-docker-dev && make up
 cat > .env << EOS
 RABBIT_AMQP=amqp://guest:guest@localhost:6672
 SUBSCRIPTION_PROJECT_ID=[SUB_PROJECT_ID]
-RECEIPT_TOPIC_PROJECT_ID=[RECEIPT_TOPIC_PROJECT_ID]
+RECEIPT_TOPIC_PROJECT_ID=[TOPIC_PROJECT_ID]
 GOOGLE_APPLICATION_CREDENTIALS=[/path/to/service/account/key.json]
 RABBIT_QUEUE=Case.Responses
 RABBIT_EXCHANGE=case-outbound-exchange
 RABBIT_ROUTE=Case.Responses.binding
 RECEIPT_TOPIC_NAME=[TOPIC_NAME]
-SUBSCRIPTION_NAME=[NEW_OR_EXISTING_SUB_NAME]
+SUBSCRIPTION_NAME=[SUBSCRIPTION_NAME]
 EOS
 ```
 
@@ -113,7 +114,8 @@ EOS
 pipenv install
 pipenv shell
 
-python test/create_topic.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
+python test/helpers/create_topic.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
+python test/helpers/create_subscription.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME $SUBSCRIPTION_NAME
 python run.py
 ```
 
@@ -125,5 +127,5 @@ docker logs casesvc -f
 * In a separate terminal, publish a message to the Pub/Sub emulator:
 ```bash
 pipenv shell
-python test/publish_message.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
+python test/helpers/publish_message.py $RECEIPT_TOPIC_PROJECT_ID $RECEIPT_TOPIC_NAME
 ```

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 import jinja2
-from google.api_core.exceptions import AlreadyExists, PermissionDenied
 from google.cloud.pubsub_v1 import SubscriberClient
 from google.cloud.pubsub_v1.subscriber.message import Message
 from rfc3339 import parse_datetime
@@ -13,8 +12,6 @@ from structlog import wrap_logger
 from app.rabbit_helper import send_message_to_rabbitmq
 
 
-RECEIPT_TOPIC_NAME = os.getenv("RECEIPT_TOPIC_NAME", "eq-submission-topic")
-RECEIPT_TOPIC_PROJECT_ID = os.getenv("RECEIPT_TOPIC_PROJECT_ID")
 SUBSCRIPTION_NAME = os.getenv("SUBSCRIPTION_NAME", "rm-receipt-subscription")
 SUBSCRIPTION_PROJECT_ID = os.getenv("SUBSCRIPTION_PROJECT_ID")
 
@@ -34,17 +31,17 @@ def receipt_to_case(message: Message):
     """
     try:
         if message.attributes['eventType'] != 'OBJECT_FINALIZE':  # receipt only on object creation
-            logger.error('Unknown message eventType', eventType=message.attributes['eventType'])
+            logger.error('Unknown Pub/Sub Message eventType', eventType=message.attributes['eventType'])
             return
         bucket_name, object_name = message.attributes['bucketId'], message.attributes['objectId']
-        logger.info('Message received for processing',
+        logger.info('Pub/Sub Message received for processing',
                     bucket_name=bucket_name,
                     message_id=message.message_id,
                     object_name=object_name)
         payload = json.loads(message.data)
         time_obj_created = parse_datetime(payload['timeCreated']).isoformat()
     except KeyError:
-        logger.exception('Message missing attribute')
+        logger.exception('Pub/Sub Message missing attribute')
         return
     xml_message = jinja_template.render(case_id=object_name,        # TODO: This assumes caseId is filename
                                         inbound_channel='OFFLINE',  # TODO: Hardcoded to OFFLINE for all response types
@@ -55,30 +52,16 @@ def receipt_to_case(message: Message):
 
 def setup_subscription(subscription_name=SUBSCRIPTION_NAME,
                        subscription_project_id=SUBSCRIPTION_PROJECT_ID,
-                       topic_name=RECEIPT_TOPIC_NAME,
-                       topic_project_id=RECEIPT_TOPIC_PROJECT_ID,
                        callback=receipt_to_case):
     """
-    Create (it not exists) a new pubsub subscription in GCP to a pubsub topic
-    and a subscriber thread which handles new messages through a callback
+    Create a subscriber thread which handles new messages through a callback
 
     :param subscription_name: The name of the pubsub subscription
-    :param subscription_project_id: GCP project where subscription should exist
-    :param topic_name: The pubsub topic to subscribe to
-    :param topic_project_id: GCP project where topic should exist
+    :param subscription_project_id: GCP project where subscription should already exist
     :param callback: The callback to use upon receipt of a new message from the subscription
     :return: a StreamingPullFuture for managing the callback thread
     """
-    topic_path = client.topic_path(topic_project_id, topic_name)
     subscription_path = client.subscription_path(subscription_project_id, subscription_name)
-    try:
-        client.create_subscription(subscription_path, topic_path)
-    except AlreadyExists:
-        logger.info('Subscription already exists', subscription_path=subscription_path, topic_path=topic_path)
-    except PermissionDenied:
-        logger.exception('Subscription can not be created')
-    else:
-        logger.info('Subscription created', subscription_path=subscription_path, topic_path=topic_path)
     subscriber_future = client.subscribe(subscription_path, callback)
-    logger.info('Listening for messages', subscription_path=subscription_path, topic_path=topic_path)
+    logger.info('Listening for Pub/Sub messages', subscription_path=subscription_path)
     return subscriber_future

--- a/test/helpers/create_subscription.py
+++ b/test/helpers/create_subscription.py
@@ -1,0 +1,23 @@
+import sys
+
+from google.api_core.exceptions import AlreadyExists, PermissionDenied
+from google.cloud import pubsub_v1
+
+
+if __name__ == '__main__':
+    subscriber = pubsub_v1.SubscriberClient()
+    try:
+        topic_path = subscriber.topic_path(sys.argv[1], sys.argv[2])
+        subscription_path = subscriber.subscription_path(sys.argv[1], sys.argv[3])
+    except IndexError:
+        print('Usage: python create_subscription.py PROJECT_ID TOPIC_ID SUBSCRIPTION_ID')
+        sys.exit()
+
+    try:
+        sub = subscriber.create_subscription(subscription_path, topic_path)
+    except AlreadyExists:
+        print('Subscription already exists')
+    except PermissionDenied:
+        print('Subscription can not be created')
+
+    print(f'Subscription created: {sub}')


### PR DESCRIPTION
## Motivation and Context
It is now assumed eQ will host the Pub/Sub Topic and Subscription within their GCP project

## What has changed
- Setup no longer creates a Pub/Sub subscription if one does not exist
- Added helper script for creating a Pub/Sub subscription (useful for the emulator)

## How to test?
- Follow the emulator section of the README

## Links
- [Unit tests](https://github.com/ONSdigital/census-rm-pubsub/pull/8) will need updating
