### PR TITLE
Break the rabbit URL into its component variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 	```bash
 	GOOGLE_APPLICATION_CREDENTIALS
 	LOG_LEVEL
-	RABBIT_AMQP
+	RABBIT_HOST
+	RABBIT_PORT
+	RABBIT_VIRTUALHOST
+	RABBIT_USERNAME
+	RABBIT_PASSWORD
 	RABBIT_QUEUE
 	RABBIT_EXCHANGE
 	RABBIT_ROUTE
@@ -65,7 +69,11 @@ cd ras-rm-docker-dev && make up
 * Create `.env` file in census-rm-pubsub directory:
 ```bash
 cat > .env << EOS
-RABBIT_AMQP=amqp://guest:guest@localhost:6672
+RABBIT_HOST=localhost
+RABBIT_PORT=6672
+RABBIT_VIRTUALHOST=/
+RABBIT_USERNAME=guest
+RABBIT_PASSWORD=guest
 SUBSCRIPTION_PROJECT_ID=[SUB_PROJECT_ID]
 RECEIPT_TOPIC_PROJECT_ID=[TOPIC_PROJECT_ID]
 GOOGLE_APPLICATION_CREDENTIALS=[/path/to/service/account/key.json]
@@ -122,7 +130,11 @@ export PUBSUB_EMULATOR_HOST=::1:8410
 * Create `.env` file in census-rm-pubsub directory:
 ```bash
 cat > .env << EOS
-RABBIT_AMQP=amqp://guest:guest@localhost:6672  # taken from ras-rm-docker-dev
+RABBIT_HOST=localhost
+RABBIT_PORT=6672
+RABBIT_VIRTUALHOST=/
+RABBIT_USERNAME=guest
+RABBIT_PASSWORD=guest
 SUBSCRIPTION_PROJECT_ID=project  # can be anything
 RECEIPT_TOPIC_PROJECT_ID=project  # can be anything
 PUBSUB_EMULATOR_HOST=localhost:8410  # taken from the env-init (above)

--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -26,7 +26,6 @@ def init_rabbitmq(binding_key=RABBIT_ROUTE,
     """
     Initialise connection to rabbitmq
 
-    :param parameters: The CollectionParameters for the connection
     :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "case-outbound-exchange")
     :param queue_name: The rabbitmq queue that subscribes to the exchange, (e.g.: "Case.Responses")
     :param binding_key: The binding key to associate the exchange and queue (e.g.: "Case.Responses.binding")

--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -4,32 +4,35 @@ import pika
 from structlog import wrap_logger
 
 
-RABBIT_AMQP = os.getenv("RABBIT_AMQP", "amqp://guest:guest@localhost:6672")
 RABBIT_EXCHANGE = os.getenv("RABBIT_EXCHANGE", "case-outbound-exchange")
 RABBIT_QUEUE = os.getenv("RABBIT_QUEUE", "Case.Responses")
 RABBIT_ROUTE = os.getenv("RABBIT_ROUTING_KEY", "Case.Responses.binding")
 RABBIT_QUEUE_ARGS = {'x-dead-letter-exchange': 'case-deadletter-exchange',
                      'x-dead-letter-routing-key': RABBIT_ROUTE}
 
+RABBIT_HOST = os.getenv("RABBIT_HOST", "localhost")
+RABBIT_PORT = os.getenv("RABBIT_PORT", "6672")
+RABBIT_VIRTUALHOST = os.getenv("RABBIT_VIRTUALHOST", "/")
+RABBIT_USERNAME = os.getenv("RABBIT_USERNAME", "guest")
+RABBIT_PASSWORD = os.getenv("RABBIT_PASSWORD", "guest")
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def init_rabbitmq(rabbitmq_amqp=RABBIT_AMQP,
-                  binding_key=RABBIT_ROUTE,
+def init_rabbitmq(binding_key=RABBIT_ROUTE,
                   exchange_name=RABBIT_EXCHANGE,
                   queue_name=RABBIT_QUEUE,
                   queue_args=RABBIT_QUEUE_ARGS):
     """
     Initialise connection to rabbitmq
 
-    :param rabbitmq_amqp: The amqp (url) of the rabbitmq connection
+    :param parameters: The CollectionParameters for the connection
     :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "case-outbound-exchange")
     :param queue_name: The rabbitmq queue that subscribes to the exchange, (e.g.: "Case.Responses")
     :param binding_key: The binding key to associate the exchange and queue (e.g.: "Case.Responses.binding")
     :param queue_args: Arguments passed to the rabbitmq queue declaration
     """
-    logger.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
-    rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
+    rabbitmq_connection = _create_connection()
     channel = rabbitmq_connection.channel()
     channel.exchange_declare(exchange=exchange_name, exchange_type='direct', durable=True)
     channel.queue_declare(queue=queue_name, durable=True, arguments=queue_args)
@@ -38,21 +41,18 @@ def init_rabbitmq(rabbitmq_amqp=RABBIT_AMQP,
 
 
 def send_message_to_rabbitmq(message,
-                             rabbitmq_amqp=RABBIT_AMQP,
                              exchange_name=RABBIT_EXCHANGE,
                              routing_key=RABBIT_ROUTE):
     """
     Send message to rabbitmq
 
     :param message: The message to send to the queue in JSON format
-    :param rabbitmq_amqp: The amqp (url) of the rabbitmq connection
     :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "case-outbound-exchange")
     :param routing_key: The direct route to a queue the message should be sent to (e.g.: "Case.Responses.binding")
     :return: boolean
     :raises: PublishMessageError
     """
-    logger.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
-    rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
+    rabbitmq_connection = _create_connection()
     rabbitmq_channel = rabbitmq_connection.channel()
     rabbitmq_channel.basic_publish(exchange=exchange_name,
                                    routing_key=routing_key,
@@ -61,3 +61,15 @@ def send_message_to_rabbitmq(message,
     logger.info('Message successfully sent to rabbitmq', exchange=exchange_name, route=routing_key)
 
     rabbitmq_connection.close()
+
+
+def _create_connection(username=RABBIT_USERNAME,
+                       password=RABBIT_PASSWORD,
+                       host=RABBIT_HOST,
+                       port=RABBIT_PORT,
+                       virtualhost=RABBIT_VIRTUALHOST):
+    credentials = pika.PlainCredentials(RABBIT_USERNAME, RABBIT_PASSWORD)
+    parameters = pika.ConnectionParameters(RABBIT_HOST, RABBIT_PORT, RABBIT_VIRTUALHOST, credentials)
+
+    logger.debug('Connecting to rabbitmq', url=parameters.host)
+    return pika.BlockingConnection(parameters)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,11 @@ services:
       test: bash -c "[ -f /app/pubsub-ready ]"
       interval: 5s
     environment:
-    - RABBIT_AMQP=amqp://guest:guest@rabbitmq-census-pubsub:5672
+    - RABBIT_HOST=rabbitmq
+    - RABBIT_PORT=5672
+    - RABBIT_VIRTUALHOST=/
+    - RABBIT_USERNAME=guest
+    - RABBIT_PASSWORD=guest
     - SUBSCRIPTION_PROJECT_ID=project
     - RECEIPT_TOPIC_PROJECT_ID=project
     - PUBSUB_EMULATOR_HOST=pubsub-emulator:8539

--- a/test/unit/test_rabbit_helper.py
+++ b/test/unit/test_rabbit_helper.py
@@ -10,7 +10,12 @@ from test import create_stub_function
 
 class RabbitHelperTestCase(TestCase):
 
-    rabbit_amqp = "amqp://user:pa55word@host:0001"
+    rabbit_username = 'user'
+    rabbit_password = 'pa55word'
+    rabbit_host = 'host'
+    rabbit_port = '0001'
+    rabbit_virtualhost = '/'
+
     binding_key = "test.binding"
     rabbit_queue = "test.queue"
     rabbit_exchange = "test-exchange"
@@ -23,7 +28,11 @@ class RabbitHelperTestCase(TestCase):
 
     def setUp(self):
         test_environment_variables = {
-            'RABBIT_AMQP': self.rabbit_amqp,
+            'RABBIT_USERNAME': self.rabbit_username,
+            'RABBIT_PASSWORD': self.rabbit_password,
+            'RABBIT_HOST': self.rabbit_host,
+            'RABBIT_PORT': self.rabbit_port,
+            'RABBIT_VIRTUALHOST': self.rabbit_virtualhost,
             'RABBIT_ROUTING_KEY': self.binding_key,
             'RABBIT_QUEUE': self.rabbit_queue,
             'RABBIT_EXCHANGE': self.rabbit_exchange,
@@ -35,17 +44,19 @@ class RabbitHelperTestCase(TestCase):
 
         with patch('app.rabbit_helper.pika') as mock_pika:
             connection_mock = MagicMock()
-            mock_pika.URLParameters = create_stub_function(self.rabbit_amqp, return_value=self.rabbit_url)
-            mock_pika.BlockingConnection = create_stub_function(self.rabbit_url, return_value=connection_mock)
+            mock_pika.BlockingConnection = create_stub_function(mock_pika.ConnectionParameters.return_value, return_value=connection_mock)
 
             channel_mock = MagicMock()
             connection_mock.channel = create_stub_function(return_value=channel_mock)
 
-            init_rabbitmq(rabbitmq_amqp=self.rabbit_amqp,
-                          binding_key=self.binding_key,
+            init_rabbitmq(binding_key=self.binding_key,
                           exchange_name=self.rabbit_exchange,
                           queue_name=self.rabbit_queue,
                           queue_args=self.queue_args)
+
+            mock_pika.PlainCredentials.assert_called_once_with(self.rabbit_username, self.rabbit_password)
+            mock_pika.ConnectionParameters.assert_called_once_with(
+                self.rabbit_host, self.rabbit_port, self.rabbit_virtualhost, mock_pika.PlainCredentials.return_value)
 
             channel_mock.exchange_declare.assert_called_once_with(exchange=self.rabbit_exchange, exchange_type='direct',
                                                                   durable=True)
@@ -67,8 +78,7 @@ class RabbitHelperTestCase(TestCase):
 
         with patch('app.rabbit_helper.pika') as mock_pika:
             connection_mock = MagicMock()
-            mock_pika.URLParameters = create_stub_function(self.rabbit_amqp, return_value=self.rabbit_url)
-            mock_pika.BlockingConnection = create_stub_function(self.rabbit_url, return_value=connection_mock)
+            mock_pika.BlockingConnection = create_stub_function(mock_pika.ConnectionParameters.return_value, return_value=connection_mock)
 
             channel_mock = MagicMock()
             connection_mock.channel = create_stub_function(return_value=channel_mock)
@@ -76,9 +86,12 @@ class RabbitHelperTestCase(TestCase):
                                                              return_value=self.property_class)
 
             send_message_to_rabbitmq(self.message,
-                                     rabbitmq_amqp=self.rabbit_amqp,
                                      exchange_name=self.rabbit_exchange,
                                      routing_key=self.binding_key)
+
+            mock_pika.PlainCredentials.assert_called_once_with(self.rabbit_username, self.rabbit_password)
+            mock_pika.ConnectionParameters.assert_called_once_with(
+                self.rabbit_host, self.rabbit_port, self.rabbit_virtualhost, mock_pika.PlainCredentials.return_value)
 
             channel_mock.basic_publish.assert_called_once_with(exchange=self.rabbit_exchange,
                                                                routing_key=self.binding_key,


### PR DESCRIPTION
## Motivation and Context
Currently the only way to set the RabbitMQ connection variables is via the compond URL parameters. This isn't ideal for when we'll want to be able to pull in the username and password from Kubernetes secrets.

## What has changed
Breaks out the Rabbit URL into its component parameters. 

## How to test?
`make test`
