### PR TITLE
remove rabbit dlq

### DIFF
--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -8,8 +8,6 @@ RABBIT_AMQP = os.getenv("RABBIT_AMQP", "amqp://guest:guest@localhost:6672")
 RABBIT_EXCHANGE = os.getenv("RABBIT_EXCHANGE", "case-outbound-exchange")
 RABBIT_QUEUE = os.getenv("RABBIT_QUEUE", "Case.Responses")
 RABBIT_ROUTE = os.getenv("RABBIT_ROUTING_KEY", "Case.Responses.binding")
-RABBIT_QUEUE_ARGS = {'x-dead-letter-exchange': 'case-deadletter-exchange',
-                     'x-dead-letter-routing-key': RABBIT_ROUTE}
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -17,8 +15,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 def init_rabbitmq(rabbitmq_amqp=RABBIT_AMQP,
                   binding_key=RABBIT_ROUTE,
                   exchange_name=RABBIT_EXCHANGE,
-                  queue_name=RABBIT_QUEUE,
-                  queue_args=RABBIT_QUEUE_ARGS):
+                  queue_name=RABBIT_QUEUE):
     """
     Initialise connection to rabbitmq
 
@@ -32,7 +29,7 @@ def init_rabbitmq(rabbitmq_amqp=RABBIT_AMQP,
     rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
     channel = rabbitmq_connection.channel()
     channel.exchange_declare(exchange=exchange_name, exchange_type='direct', durable=True)
-    channel.queue_declare(queue=queue_name, durable=True, arguments=queue_args)
+    channel.queue_declare(queue=queue_name, durable=True)
     channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=binding_key)
     logger.info('Successfully initialised rabbitmq', exchange=exchange_name, binding=binding_key)
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -14,8 +14,6 @@ RABBIT_QUEUE = "Case.Responses"
 RABBIT_EXCHANGE = "case-outbound-exchange"
 RABBIT_ROUTE = "Case.Responses.binding"
 RECEIPT_TOPIC_NAME = "eq-submission-topic"
-RABBIT_QUEUE_ARGS = {'x-dead-letter-exchange': 'case-deadletter-exchange',
-                     'x-dead-letter-routing-key': RABBIT_ROUTE}
 
 
 class CensusRMPubSubComponentTest(TestCase):
@@ -77,11 +75,10 @@ class CensusRMPubSubComponentTest(TestCase):
     def init_rabbitmq(self, rabbitmq_amqp=RABBIT_AMQP,
                       binding_key=RABBIT_ROUTE,
                       exchange_name=RABBIT_EXCHANGE,
-                      queue_name=RABBIT_QUEUE,
-                      queue_args=RABBIT_QUEUE_ARGS):
+                      queue_name=RABBIT_QUEUE):
         rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
         channel = rabbitmq_connection.channel()
         channel.exchange_declare(exchange=exchange_name, exchange_type='direct', durable=True)
-        queue_declare_result = channel.queue_declare(queue=queue_name, durable=True, arguments=queue_args)
+        queue_declare_result = channel.queue_declare(queue=queue_name, durable=True)
         channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=binding_key)
         return channel, queue_declare_result

--- a/test/unit/test_rabbit_helper.py
+++ b/test/unit/test_rabbit_helper.py
@@ -18,8 +18,6 @@ class RabbitHelperTestCase(TestCase):
     rabbit_url = 'rabbit_url'
     rabbit_connection = 'rabbit connection'
     message = "message test"
-    queue_args = {'x-dead-letter-exchange': 'case-deadletter-exchange',
-                  'x-dead-letter-routing-key': binding_key}
 
     def setUp(self):
         test_environment_variables = {
@@ -44,12 +42,11 @@ class RabbitHelperTestCase(TestCase):
             init_rabbitmq(rabbitmq_amqp=self.rabbit_amqp,
                           binding_key=self.binding_key,
                           exchange_name=self.rabbit_exchange,
-                          queue_name=self.rabbit_queue,
-                          queue_args=self.queue_args)
+                          queue_name=self.rabbit_queue)
 
             channel_mock.exchange_declare.assert_called_once_with(exchange=self.rabbit_exchange, exchange_type='direct',
                                                                   durable=True)
-            channel_mock.queue_declare.assert_called_once_with(arguments=self.queue_args, durable=True,
+            channel_mock.queue_declare.assert_called_once_with(durable=True,
                                                                queue=self.rabbit_queue)
             channel_mock.queue_bind.assert_called_once_with(exchange=self.rabbit_exchange,
                                                             queue=self.rabbit_queue,


### PR DESCRIPTION
## Motivation and Context
Now that case processor is using the case.Responses queue it expects there to be no dlq, these have been removed from pubsub

## What has changed
Removed dlq args from rabbitmq setup

## How to test?
This should make the case processor receipting work reliably.
With a clean rabbitmq (make down, remove image etc), and the correct version of case-processor: https://github.com/ONSdigital/census-rm-case-processor/pull/8
Once you've made up in docker dev, you should be able to run the acceptance-tests from  branch:
https://github.com/ONSdigital/census-rm-acceptance-tests/tree/pubsub-receipting

## Links
https://trello.com/c/2lcQkGCO/674-case-processor-should-handle-receipt-message-from-pubsub-service-8
