### PR TITLE
Remove Docker image push from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,11 @@ script:
   - make package_vulnerability
   - make flake
   - make unit_test_coverage
+  - make docker_build
   - make component_tests
 
 after_success:
   - pipenv run codecov
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
-    docker build -t "$DESTINATION_IMAGE_NAME" .;
-    docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-    docker push "$DESTINATION_IMAGE_NAME";
-    fi
 
 env:
   global:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Concourse will now handle the building and pushing of our Docker services to GCR.

## What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added fail on docker build to script section of Travis file
