### PR TITLE
Handle refusal event

### DIFF
--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -50,11 +50,10 @@ def send_message_to_rabbitmq(message,
     """
     rabbitmq_connection = _create_connection()
     rabbitmq_channel = rabbitmq_connection.channel()
-    headers = {'source': 'RECEIPTING', 'channel': 'EQ'}
     rabbitmq_channel.basic_publish(exchange=exchange_name,
                                    routing_key=routing_key,
                                    body=str(message),
-                                   properties=pika.BasicProperties(content_type='application/json', headers=headers))
+                                   properties=pika.BasicProperties(content_type='application/json'))
     logger.info('Message successfully sent to rabbitmq', exchange=exchange_name, route=routing_key)
 
     rabbitmq_connection.close()

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -79,7 +79,7 @@ def receipt_to_case(message: Message):
     receiptMessage['event'] = eventObject
     receiptMessage['payload'] = payloadObject
 
-    send_message_to_rabbitmq(json.dumps(receiptMessage))  # NB: in the future this should hold `questionnaire_id`
+    send_message_to_rabbitmq(json.dumps(receiptMessage))
     message.ack()
 
     log.info('Message processing complete')

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -63,7 +63,7 @@ def receipt_to_case(message: Message):
     responseObject = {}
 
     eventObject['type'] = 'RESPONSE_RECEIVED'
-    eventObject['source'] = 'RECEIPTING'
+    eventObject['source'] = 'RECEIPT_SERVICE'
     eventObject['channel'] = 'EQ'
     eventObject['dateTime'] = time_obj_created
     eventObject['transactionId'] = tx_id

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -59,27 +59,24 @@ def receipt_to_case(message: Message):
 
     metadata['response_datetime'] = time_obj_created
 
-    receiptMessage = {}
-    eventObject = {}
-    payloadObject = {}
-    responseObject = {}
+    receipt_message = {
+        'event': {
+            'type': 'RESPONSE_RECEIVED',
+            'source': 'RECEIPT_SERVICE',
+            'channel': 'EQ',
+            'dateTime': time_obj_created,
+            'transactionId': tx_id
+        },
+        'payload': {
+            'response': {
+                'caseId': case_id,
+                'questionnaireId': questionnaire_id,
+                'unreceipt': False
+            }
+        }
+    }
 
-    eventObject['type'] = 'RESPONSE_RECEIVED'
-    eventObject['source'] = 'RECEIPT_SERVICE'
-    eventObject['channel'] = 'EQ'
-    eventObject['dateTime'] = time_obj_created
-    eventObject['transactionId'] = tx_id
-
-    responseObject['caseId'] = case_id
-    responseObject['questionnaireId'] = questionnaire_id
-    responseObject['unreceipt'] = 'false'
-
-    payloadObject['response'] = responseObject
-
-    receiptMessage['event'] = eventObject
-    receiptMessage['payload'] = payloadObject
-
-    send_message_to_rabbitmq(json.dumps(receiptMessage))
+    send_message_to_rabbitmq(json.dumps(receipt_message))
     message.ack()
 
     log.info('Message processing complete')

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -57,8 +57,6 @@ def receipt_to_case(message: Message):
 
     log = log.bind(questionnaire_id=questionnaire_id, created=time_obj_created, tx_id=tx_id, case_id=case_id)
 
-    metadata['response_datetime'] = time_obj_created
-
     receipt_message = {
         'event': {
             'type': 'RESPONSE_RECEIVED',

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -74,7 +74,6 @@ class CensusRMPubSubComponentTest(TestCase):
         })
 
         self.init_rabbitmq()
-        time.sleep(1)
         assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
 
         actual_msg_body_str = self.get_msg_body_from_rabbit(self.channel)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -40,7 +40,7 @@ class CensusRMPubSubComponentTest(TestCase):
                 "response": {
                     "caseId": expected_case_id,
                     "questionnaireId": expected_q_id,
-                    "unreceipt": "false"
+                    "unreceipt": False
                 }
             }
         })
@@ -68,7 +68,7 @@ class CensusRMPubSubComponentTest(TestCase):
                 "response": {
                     "caseId": None,
                     "questionnaireId": expected_q_id,
-                    "unreceipt": "false"
+                    "unreceipt": False
                 }
             }
         })

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -8,7 +8,6 @@ from coverage.python import os
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import pubsub_v1
 
-
 RABBIT_AMQP = "amqp://guest:guest@localhost:35672"
 RECEIPT_TOPIC_PROJECT_ID = "project"
 RABBIT_QUEUE = "Case.Responses"
@@ -29,10 +28,22 @@ class CensusRMPubSubComponentTest(TestCase):
         expected_q_id = str(uuid.uuid4())
         self.publish_to_pubsub(expected_tx_id, expected_q_id, expected_case_id)
 
-        expected_msg = json.dumps({'tx_id': expected_tx_id,
-                                   'questionnaire_id': expected_q_id,
-                                   'case_id': expected_case_id,
-                                   'response_datetime': '2008-08-24T00:00:00+00:00'})
+        expected_msg = json.dumps({
+            "event": {
+                "type": "RESPONSE_RECEIVED",
+                "source": "RECEIPT_SERVICE",
+                "channel": "EQ",
+                "dateTime": "2008-08-24T00:00:00+00:00",
+                "transactionId": expected_tx_id
+            },
+            "payload": {
+                "response": {
+                    "caseId": expected_case_id,
+                    "questionnaireId": expected_q_id,
+                    "unreceipt": "false"
+                }
+            }
+        })
 
         self.init_rabbitmq()
         assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
@@ -45,11 +56,25 @@ class CensusRMPubSubComponentTest(TestCase):
         expected_q_id = str(uuid.uuid4())
         self.publish_to_pubsub(expected_tx_id, expected_q_id)
 
-        expected_msg = json.dumps({'tx_id': expected_tx_id,
-                                   'questionnaire_id': expected_q_id,
-                                   'response_datetime': '2008-08-24T00:00:00+00:00'})
+        expected_msg = json.dumps({
+            "event": {
+                "type": "RESPONSE_RECEIVED",
+                "source": "RECEIPT_SERVICE",
+                "channel": "EQ",
+                "dateTime": "2008-08-24T00:00:00+00:00",
+                "transactionId": expected_tx_id
+            },
+            "payload": {
+                "response": {
+                    "caseId": None,
+                    "questionnaireId": expected_q_id,
+                    "unreceipt": "false"
+                }
+            }
+        })
 
         self.init_rabbitmq()
+        time.sleep(1)
         assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
 
         actual_msg_body_str = self.get_msg_body_from_rabbit(self.channel)

--- a/test/unit/test_rabbit_helper.py
+++ b/test/unit/test_rabbit_helper.py
@@ -81,9 +81,7 @@ class RabbitHelperTestCase(TestCase):
 
             channel_mock = MagicMock()
             connection_mock.channel = create_stub_function(return_value=channel_mock)
-            mock_pika.BasicProperties = create_stub_function(expected_kwargs={'content_type': 'application/json',
-                                                                              'headers': {'source': 'RECEIPTING',
-                                                                                          'channel': 'EQ'}},
+            mock_pika.BasicProperties = create_stub_function(expected_kwargs={'content_type': 'application/json'},
                                                              return_value=self.property_class)
 
             send_message_to_rabbitmq(self.message,

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -107,7 +107,8 @@ class TestSubscriber(TestCase):
                                    'bucketId': self.gcp_bucket,
                                    'objectId': self.gcp_object_id}
         mock_message.data = json.dumps(
-            {"metadata": {"tx_id": "1", "questionnaire_id": self.questionnaire_id, "case_id": self.case_id}, "timeCreated": self.created})
+            {"metadata": {"tx_id": "1", "questionnaire_id": self.questionnaire_id, "case_id": self.case_id},
+             "timeCreated": self.created})
         mock_message.message_id = str(uuid.uuid4())
 
         create_stub_function(self.created, return_value=self.parsed_created)
@@ -141,7 +142,7 @@ class TestSubscriber(TestCase):
                     }
                 }
             })
-        
+
         from app.subscriber import receipt_to_case
 
         with self.checkExpectedLogLine('INFO', expected_log_event, expected_log_kwargs):
@@ -385,7 +386,8 @@ class TestSubscriber(TestCase):
         mock_message.attributes = {'eventType': 'OBJECT_FINALIZE',
                                    'bucketId': self.gcp_bucket,
                                    'objectId': self.gcp_object_id}
-        mock_message.data = json.dumps({"metadata": {"tx_id": "1", "questionnaire_id": "0120000000001000"}, "timeCreated": "123"})
+        mock_message.data = json.dumps(
+            {"metadata": {"tx_id": "1", "questionnaire_id": "0120000000001000"}, "timeCreated": "123"})
 
         expected_log_event = 'Pub/Sub Message has invalid RFC 3339 timeCreated datetime string'
         expected_log_kwargs = {

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -125,11 +125,23 @@ class TestSubscriber(TestCase):
             'message_id': mock_message.message_id
         }
 
-        expected_rabbit_message = json.dumps({'tx_id': '1',
-                                              'questionnaire_id': self.questionnaire_id,
-                                              'case_id': self.case_id,
-                                              'response_datetime': '2008-08-24T00:00:00+00:00'})
-
+        expected_rabbit_message = json.dumps(
+            {'event': {
+                'type': 'RESPONSE_RECEIVED',
+                'source': 'RECEIPT_SERVICE',
+                'channel': 'EQ',
+                'dateTime': '2008-08-24T00:00:00+00:00',
+                'transactionId': '1'
+            },
+                'payload': {
+                    'response': {
+                        'caseId': self.case_id,
+                        'questionnaireId': self.questionnaire_id,
+                        'unreceipt': "false"
+                    }
+                }
+            })
+        
         from app.subscriber import receipt_to_case
 
         with self.checkExpectedLogLine('INFO', expected_log_event, expected_log_kwargs):

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -138,7 +138,7 @@ class TestSubscriber(TestCase):
                     'response': {
                         'caseId': self.case_id,
                         'questionnaireId': self.questionnaire_id,
-                        'unreceipt': "false"
+                        'unreceipt': False
                     }
                 }
             })


### PR DESCRIPTION
## Motivation and Context
Receipt message structure not matching event spec
<!--- Why is this change required? What problem does it solve? -->

## What has changed
Receipt message structure change as per event spec
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

## How to test?
[as per](https://github.com/ONSdigital/census-rm-case-processor/pull/30)
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

## Links
[Trello](https://trello.com/c/29ZsK7ci/825-rmc-197-handle-refusal-received-event-rev13-8)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
