### PR TITLE
Handle Paper Questionnaire Receipts

### DIFF
--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -12,6 +12,7 @@ from app.rabbit_helper import send_message_to_rabbitmq
 
 
 SUBSCRIPTION_NAME = os.getenv("SUBSCRIPTION_NAME", "rm-receipt-subscription")
+OFFLINE_SUBSCRIPTION_NAME = os.getenv("OFFLINE_SUBSCRIPTION_NAME", "rm-offline-receipt-subscription")
 SUBSCRIPTION_PROJECT_ID = os.getenv("SUBSCRIPTION_PROJECT_ID")
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -78,6 +79,14 @@ def receipt_to_case(message: Message):
     message.ack()
 
     log.info('Message processing complete')
+
+
+def offline_receipt_to_case(message: Message):
+    log = logger.bind(message_id=message.message_id,
+                      subscription_name=SUBSCRIPTION_NAME,
+                      subscription_project=SUBSCRIPTION_PROJECT_ID)
+    log.info('testing')
+    pass
 
 
 def setup_subscription(subscription_name=SUBSCRIPTION_NAME,

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -83,10 +83,47 @@ def receipt_to_case(message: Message):
 
 def offline_receipt_to_case(message: Message):
     log = logger.bind(message_id=message.message_id,
-                      subscription_name=SUBSCRIPTION_NAME,
+                      subscription_name=OFFLINE_SUBSCRIPTION_NAME,
                       subscription_project=SUBSCRIPTION_PROJECT_ID)
-    log.info('testing')
-    pass
+
+    log.info('Pub/Sub Message received for processing')
+
+    try:
+        payload = json.loads(message.data)  # parse metadata as JSON payload
+        tx_id, questionnaire_id, channel = payload['transactionId'], payload['questionnaireId'], payload['channel']
+        time_obj_created = parse_datetime(payload['dateTime']).isoformat()
+    except (TypeError, json.JSONDecodeError):
+        log.error('Pub/Sub Message data not JSON')
+        return
+    except KeyError as e:
+        log.error('Pub/Sub Message missing required data', missing_json_key=e.args[0])
+        return
+    except ValueError:
+        log.error('Pub/Sub Message has invalid RFC 3339 timeCreated datetime string')
+        return
+
+    log = log.bind(questionnaire_id=questionnaire_id, created=time_obj_created, tx_id=tx_id, channel=channel)
+
+    receipt_message = {
+        'event': {
+            'type': 'RESPONSE_RECEIVED',
+            'source': 'RECEIPT_SERVICE',
+            'channel': channel,
+            'dateTime': time_obj_created,
+            'transactionId': tx_id
+        },
+        'payload': {
+            'response': {
+                'questionnaireId': questionnaire_id,
+                'unreceipt': False
+            }
+        }
+    }
+
+    send_message_to_rabbitmq(json.dumps(receipt_message))
+    message.ack()
+
+    log.info('Message processing complete')
 
 
 def setup_subscription(subscription_name=SUBSCRIPTION_NAME,

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -14,6 +14,7 @@ from app.rabbit_helper import send_message_to_rabbitmq
 SUBSCRIPTION_NAME = os.getenv("SUBSCRIPTION_NAME", "rm-receipt-subscription")
 OFFLINE_SUBSCRIPTION_NAME = os.getenv("OFFLINE_SUBSCRIPTION_NAME", "rm-offline-receipt-subscription")
 SUBSCRIPTION_PROJECT_ID = os.getenv("SUBSCRIPTION_PROJECT_ID")
+OFFLINE_SUBSCRIPTION_PROJECT_ID = os.getenv("OFFLINE_SUBSCRIPTION_PROJECT_ID")
 
 logger = wrap_logger(logging.getLogger(__name__))
 client = SubscriberClient()
@@ -84,7 +85,7 @@ def receipt_to_case(message: Message):
 def offline_receipt_to_case(message: Message):
     log = logger.bind(message_id=message.message_id,
                       subscription_name=OFFLINE_SUBSCRIPTION_NAME,
-                      subscription_project=SUBSCRIPTION_PROJECT_ID)
+                      subscription_project=OFFLINE_SUBSCRIPTION_PROJECT_ID)
 
     log.info('Pub/Sub Message received for processing')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,5 @@ services:
     - RABBIT_ROUTE=event.response.receipt
     - RECEIPT_TOPIC_NAME=eq-submission-topic
     - SUBSCRIPTION_NAME=rm-receipt-subscription
+    - OFFLINE_RECEIPT_TOPIC_NAME=offline-receipt-topic
+    - OFFLINE_SUBSCRIPTION_NAME=rm-offline-receipt-subscription

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     - RABBIT_PASSWORD=guest
     - SUBSCRIPTION_PROJECT_ID=project
     - RECEIPT_TOPIC_PROJECT_ID=project
+    - OFFLINE_SUBSCRIPTION_PROJECT_ID=offline-project
+    - OFFLINE_RECEIPT_TOPIC_PROJECT_ID=offline-project
     - PUBSUB_EMULATOR_HOST=pubsub-emulator:8539
     - RABBIT_EXCHANGE=events
     - RABBIT_ROUTE=event.response.receipt

--- a/run.py
+++ b/run.py
@@ -8,7 +8,8 @@ from structlog import wrap_logger
 from app.app_logging import logger_initial_config
 from app.readiness import Readiness
 from app.rabbit_helper import init_rabbitmq
-from app.subscriber import setup_subscription, OFFLINE_SUBSCRIPTION_NAME, offline_receipt_to_case
+from app.subscriber import setup_subscription, OFFLINE_SUBSCRIPTION_NAME, offline_receipt_to_case, \
+    OFFLINE_SUBSCRIPTION_PROJECT_ID
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -22,7 +23,8 @@ def main():
     init_rabbitmq()  # test the connection to the rabbitmq cluster
 
     futures = [setup_subscription(),
-               setup_subscription(subscription_name=OFFLINE_SUBSCRIPTION_NAME, callback=offline_receipt_to_case)]
+               setup_subscription(subscription_name=OFFLINE_SUBSCRIPTION_NAME, callback=offline_receipt_to_case,
+                                  subscription_project_id=OFFLINE_SUBSCRIPTION_PROJECT_ID)]
 
     with Readiness(os.getenv('READINESS_FILE_PATH',
                              os.path.join(os.getcwd(), 'pubsub-ready'))):  # Indicate ready after successful setup

--- a/run.py
+++ b/run.py
@@ -31,9 +31,8 @@ def main():
         with ThreadPoolExecutor(max_workers=2) as executor:
             for background_pubsub_task in futures:
                 executor_futures.append(executor.submit(background_pubsub_task.result, timeout=None))
-
-        with as_completed(executor_futures) as finished_future:
-            raise finished_future.exception(timeout=0) or RuntimeError('Thead exited unexpectedly')
+            with as_completed(executor_futures) as finished_future:
+                raise finished_future.exception(timeout=0) or RuntimeError('Thead exited unexpectedly')
 
 
 if __name__ == '__main__':

--- a/setup_pubsub.sh
+++ b/setup_pubsub.sh
@@ -2,8 +2,10 @@
 
 sleep 20s
 
-source .env
+#source .env
 
 echo 'Running setup_pubsub.sh'
 curl -X PUT http://localhost:8539/v1/projects/$RECEIPT_TOPIC_PROJECT_ID/topics/$RECEIPT_TOPIC_NAME
+curl -X PUT http://localhost:8539/v1/projects/$RECEIPT_TOPIC_PROJECT_ID/topics/$OFFLINE_RECEIPT_TOPIC_NAME
 curl -X PUT http://localhost:8539/v1/projects/$RECEIPT_TOPIC_PROJECT_ID/subscriptions/$SUBSCRIPTION_NAME -H 'Content-Type: application/json' -d '{"topic": "projects/'$RECEIPT_TOPIC_PROJECT_ID'/topics/'$RECEIPT_TOPIC_NAME'"}'
+curl -X PUT http://localhost:8539/v1/projects/$RECEIPT_TOPIC_PROJECT_ID/subscriptions/$OFFLINE_SUBSCRIPTION_NAME -H 'Content-Type: application/json' -d '{"topic": "projects/'$RECEIPT_TOPIC_PROJECT_ID'/topics/'$OFFLINE_RECEIPT_TOPIC_NAME'"}'

--- a/setup_pubsub.sh
+++ b/setup_pubsub.sh
@@ -2,7 +2,7 @@
 
 sleep 20s
 
-#source .env
+source .env
 
 echo 'Running setup_pubsub.sh'
 curl -X PUT http://localhost:8539/v1/projects/$RECEIPT_TOPIC_PROJECT_ID/topics/$RECEIPT_TOPIC_NAME

--- a/test/component/setup_pubsub.sh
+++ b/test/component/setup_pubsub.sh
@@ -24,11 +24,11 @@ wait_for_curl_success() {
 }
 
 wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/eq-submission-topic" "PUT" "pubsub_emulator topic"
-wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/offline-receipt-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8539/v1/projects/offline-project/topics/offline-receipt-topic" "PUT" "pubsub_emulator topic"
 
 echo "Setting up subscriptions to topics..."
 curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
-curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/offline-receipt-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/offline-project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/offline-project/topics/offline-receipt-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:49672/api/aliveness-test/%2F" "GET" "rabbit_mq"
 

--- a/test/component/setup_pubsub.sh
+++ b/test/component/setup_pubsub.sh
@@ -24,9 +24,11 @@ wait_for_curl_success() {
 }
 
 wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/eq-submission-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/offline-receipt-topic" "PUT" "pubsub_emulator topic"
 
-echo "Setting up subscription to topic..."
+echo "Setting up subscriptions to topics..."
 curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/offline-receipt-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:49672/api/aliveness-test/%2F" "GET" "rabbit_mq"
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -14,6 +14,7 @@ RABBIT_TEST_QUEUE = "test.case"
 RABBIT_EXCHANGE = "events"
 RABBIT_ROUTE = "event.response.receipt"
 RECEIPT_TOPIC_NAME = "eq-submission-topic"
+OFFLINE_RECEIPT_TOPIC_NAME = "offline-receipt-topic"
 
 
 class CensusRMPubSubComponentTest(TestCase):
@@ -39,6 +40,33 @@ class CensusRMPubSubComponentTest(TestCase):
             "payload": {
                 "response": {
                     "caseId": expected_case_id,
+                    "questionnaireId": expected_q_id,
+                    "unreceipt": False
+                }
+            }
+        })
+
+        self.init_rabbitmq()
+        assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
+
+        case_msg = self.get_msg_body_from_rabbit(RABBIT_TEST_QUEUE)
+        assert expected_msg == case_msg, "RabbitMQ message text incorrect"
+
+    def test_offline_e2e_with_sucessful_msg(self):
+        expected_tx_id = str(uuid.uuid4())
+        expected_q_id = str(uuid.uuid4())
+        self.publish_offline_to_pubsub(expected_tx_id, expected_q_id)
+
+        expected_msg = json.dumps({
+            "event": {
+                "type": "RESPONSE_RECEIVED",
+                "source": "RECEIPT_SERVICE",
+                "channel": "PQRS",
+                "dateTime": "2008-08-24T00:00:00+00:00",
+                "transactionId": expected_tx_id
+            },
+            "payload": {
+                "response": {
                     "questionnaireId": expected_q_id,
                     "unreceipt": False
                 }
@@ -110,6 +138,29 @@ class CensusRMPubSubComponentTest(TestCase):
                                    eventType='OBJECT_FINALIZE',
                                    bucketId='123',
                                    objectId=tx_id)
+        if not future.done():
+            time.sleep(1)
+        try:
+            future.result(timeout=30)
+        except GoogleAPIError:
+            assert False, "Failed to publish message to pubsub"
+
+        print(f'Message published to {topic_path}')
+
+    def publish_offline_to_pubsub(self, tx_id, questionnaire_id):
+        publisher = pubsub_v1.PublisherClient()
+
+        topic_path = publisher.topic_path(RECEIPT_TOPIC_PROJECT_ID, OFFLINE_RECEIPT_TOPIC_NAME)
+
+        datadict = {"dateTime": "2008-08-24T00:00:00Z", "productCode": "H1", "channel": "PQRS",
+                    "questionnaireId": questionnaire_id,
+                    "source": "RECEIPT-SERVICE", "type": "FULFILMENT_CONFIRMED",
+                    "transactionId": tx_id}
+
+        data = json.dumps(datadict)
+
+        future = publisher.publish(topic_path,
+                                   data=data.encode('utf-8'))
         if not future.done():
             time.sleep(1)
         try:

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -10,6 +10,7 @@ from google.cloud import pubsub_v1
 
 RABBIT_AMQP = "amqp://guest:guest@localhost:35672"
 RECEIPT_TOPIC_PROJECT_ID = "project"
+OFFLINE_RECEIPT_TOPIC_PROJECT_ID = "offline-project"
 RABBIT_TEST_QUEUE = "test.case"
 RABBIT_EXCHANGE = "events"
 RABBIT_ROUTE = "event.response.receipt"
@@ -150,7 +151,7 @@ class CensusRMPubSubComponentTest(TestCase):
     def publish_offline_to_pubsub(self, tx_id, questionnaire_id):
         publisher = pubsub_v1.PublisherClient()
 
-        topic_path = publisher.topic_path(RECEIPT_TOPIC_PROJECT_ID, OFFLINE_RECEIPT_TOPIC_NAME)
+        topic_path = publisher.topic_path(OFFLINE_RECEIPT_TOPIC_PROJECT_ID, OFFLINE_RECEIPT_TOPIC_NAME)
 
         datadict = {"dateTime": "2008-08-24T00:00:00Z", "productCode": "H1", "channel": "PQRS",
                     "questionnaireId": questionnaire_id,

--- a/test/scripts/publish_offline_message.py
+++ b/test/scripts/publish_offline_message.py
@@ -1,0 +1,30 @@
+import json
+import sys
+import time
+
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import pubsub_v1
+
+if __name__ == '__main__':
+    publisher = pubsub_v1.PublisherClient()
+    try:
+        topic_path = publisher.topic_path(sys.argv[1], sys.argv[2])
+    except IndexError:
+        print('Usage: python publish_offline_message.py PROJECT_ID TOPIC_ID')
+        sys.exit()
+
+    data = json.dumps(
+        {"dateTime": "2008-08-24T00:00:00Z", "productCode": "H1", "channel": "PQRS", "questionnaireId": "1100000000113",
+         "source": "RECEIPT-SERVICE", "type": "FULFILMENT_CONFIRMED",
+         "transactionId": "d34d68de-96df-431d-abe7-559b5c6aa325"})
+
+    future = publisher.publish(topic_path,
+                               data=data.encode('utf-8'))
+    if not future.done():
+        time.sleep(1)
+    try:
+        future.result(timeout=30)
+    except GoogleAPIError:
+        print("Failed to publish message to pubsub")
+
+    print(f'Message published to {topic_path}')

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -10,6 +10,7 @@ from test import create_stub_function
 
 class TestSubscriber(TestCase):
     subscription_name = 'test-subscription'
+    offline_subscription_name = 'test-offline-subscription'
     subscription_project_id = 'test-project-id'
     case_id = 'e079cea4-1447-4529-aa70-8757f1806f60'
     questionnaire_id = '0120000000001000'
@@ -79,6 +80,7 @@ class TestSubscriber(TestCase):
     def setUp(self):
         test_environment_variables = {
             'SUBSCRIPTION_NAME': self.subscription_name,
+            'OFFLINE_SUBSCRIPTION_NAME': self.offline_subscription_name,
             'SUBSCRIPTION_PROJECT_ID': self.subscription_project_id,
         }
         os.environ.update(test_environment_variables)
@@ -147,6 +149,50 @@ class TestSubscriber(TestCase):
 
         with self.checkExpectedLogLine('INFO', expected_log_event, expected_log_kwargs):
             receipt_to_case(mock_message)
+
+        mock_send_message_to_rabbit_mq.assert_called_once_with(expected_rabbit_message)
+        mock_message.ack.assert_called_once()
+
+    @patch('app.subscriber.send_message_to_rabbitmq')
+    def test_offline_receipt_to_case(self, mock_send_message_to_rabbit_mq):
+        mock_message = MagicMock()
+        mock_message.data = json.dumps(
+            {"transactionId": "1", "questionnaireId": self.questionnaire_id, "dateTime": self.created, "channel": "PQRS"})
+        mock_message.message_id = str(uuid.uuid4())
+
+        create_stub_function(self.created, return_value=self.parsed_created)
+
+        expected_log_event = 'Message processing complete'
+        expected_log_kwargs = {
+            'questionnaire_id': self.questionnaire_id,
+            'created': self.parsed_created,
+            'tx_id': '1',
+            'channel': 'PQRS',
+            'subscription_name': self.offline_subscription_name,
+            'subscription_project': self.subscription_project_id,
+            'message_id': mock_message.message_id
+        }
+
+        expected_rabbit_message = json.dumps(
+            {'event': {
+                'type': 'RESPONSE_RECEIVED',
+                'source': 'RECEIPT_SERVICE',
+                'channel': 'PQRS',
+                'dateTime': '2008-08-24T00:00:00+00:00',
+                'transactionId': '1'
+            },
+                'payload': {
+                    'response': {
+                        'questionnaireId': self.questionnaire_id,
+                        'unreceipt': False
+                    }
+                }
+            })
+
+        from app.subscriber import offline_receipt_to_case
+
+        with self.checkExpectedLogLine('INFO', expected_log_event, expected_log_kwargs):
+            offline_receipt_to_case(mock_message)
 
         mock_send_message_to_rabbit_mq.assert_called_once_with(expected_rabbit_message)
         mock_message.ack.assert_called_once()

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -12,6 +12,7 @@ class TestSubscriber(TestCase):
     subscription_name = 'test-subscription'
     offline_subscription_name = 'test-offline-subscription'
     subscription_project_id = 'test-project-id'
+    offline_subscription_project_id = 'test-offline-project-id'
     case_id = 'e079cea4-1447-4529-aa70-8757f1806f60'
     questionnaire_id = '0120000000001000'
     created = '2008-08-24T00:00:00Z'
@@ -82,6 +83,7 @@ class TestSubscriber(TestCase):
             'SUBSCRIPTION_NAME': self.subscription_name,
             'OFFLINE_SUBSCRIPTION_NAME': self.offline_subscription_name,
             'SUBSCRIPTION_PROJECT_ID': self.subscription_project_id,
+            'OFFLINE_SUBSCRIPTION_PROJECT_ID': self.offline_subscription_project_id
         }
         os.environ.update(test_environment_variables)
 
@@ -169,7 +171,7 @@ class TestSubscriber(TestCase):
             'tx_id': '1',
             'channel': 'PQRS',
             'subscription_name': self.offline_subscription_name,
-            'subscription_project': self.subscription_project_id,
+            'subscription_project': self.offline_subscription_project_id,
             'message_id': mock_message.message_id
         }
 


### PR DESCRIPTION
## Motivation and Context
We need to process receipts from PQRS and QM so that we no longer chase cases who have responded with a paper questionnaire.

## What has changed
- Added a new pubsub topic
- Add a new subscription
- Transformed receipt messages into pre-existing receipt format

## How to test?
- Bring everything up  in Docker using the branch linked below
- Run the acceptance tests

## Links
https://trello.com/c/conn8do9
https://github.com/ONSdigital/census-rm-docker-dev/pull/28
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/110