### PR TITLE
Remove exchange declaration from raabbitmq init

### DIFF
--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -22,8 +22,7 @@ def init_rabbitmq(exchange_name=RABBIT_EXCHANGE):
     :param exchange_name: The rabbitmq exchange to publish to, (e.g.: "events")
     """
     rabbitmq_connection = _create_connection()
-    channel = rabbitmq_connection.channel()
-    channel.exchange_declare(exchange=exchange_name, exchange_type='topic', durable=True)
+    _ = rabbitmq_connection.channel()
 
     logger.info('Successfully initialised rabbitmq', exchange=exchange_name)
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -123,6 +123,7 @@ class CensusRMPubSubComponentTest(TestCase):
                       binding_key=RABBIT_ROUTE,
                       exchange_name=RABBIT_EXCHANGE,
                       queue_name=RABBIT_TEST_QUEUE):
+        # NB: instead of pre-loading a definitions.json file we have programmatically declared what we need for the test
         rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
         channel = rabbitmq_connection.channel()
         channel.exchange_declare(exchange=exchange_name, exchange_type='topic', durable=True)

--- a/test/unit/test_rabbit_helper.py
+++ b/test/unit/test_rabbit_helper.py
@@ -52,9 +52,6 @@ class RabbitHelperTestCase(TestCase):
             mock_pika.ConnectionParameters.assert_called_once_with(
                 self.rabbit_host, self.rabbit_port, self.rabbit_virtualhost, mock_pika.PlainCredentials.return_value)
 
-            channel_mock.exchange_declare.assert_called_once_with(exchange=self.rabbit_exchange, exchange_type='topic',
-                                                                  durable=True)
-
     def test_initialise_messaging_rabbit_fails(self):
         from app.rabbit_helper import init_rabbitmq
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Towards a single source of truth for rabbit queue definitions!

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed rabbitmq exchange declaration

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- `make test`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- [Source of truth for k8s](https://github.com/ONSdigital/census-rm-kubernetes/pull/103)
- [Trello card ](https://trello.com/c/QGjPdQvO)
