### PR TITLE
Add PPO & QM subscriptions etc

### DIFF
--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import uuid
 
 from google.cloud.pubsub_v1 import SubscriberClient
 from google.cloud.pubsub_v1.subscriber.message import Message
@@ -127,13 +126,13 @@ def ppo_undelivered_mail_to_case(message: Message):
 
     log.debug('Pub/Sub Message received for processing')
 
-    payload = validate_message(message.data, log, ['caseRef', 'productCode'])
+    payload = validate_message(message.data, log, ['transactionId', 'caseRef', 'productCode'])
     if not payload:
         return  # Failed validation
 
-    case_ref, product_code, date_time = payload['caseRef'], payload['productCode'], payload['dateTime']
+    tx_id, case_ref, product_code, date_time = payload['transactionId'], payload['caseRef'], payload['productCode'], payload['dateTime']
 
-    log = log.bind(case_ref=case_ref, created=date_time, product_code=product_code)
+    log = log.bind(case_ref=case_ref, created=date_time, product_code=product_code, tx_id=tx_id)
 
     receipt_message = {
         'event': {
@@ -141,7 +140,7 @@ def ppo_undelivered_mail_to_case(message: Message):
             'source': 'RECEIPT_SERVICE',
             'channel': 'PPO',
             'dateTime': date_time,
-            'transactionId': str(uuid.uuid4())
+            'transactionId': tx_id
         },
         'payload': {
             'fulfilmentInformation': {
@@ -164,13 +163,13 @@ def qm_undelivered_mail_to_case(message: Message):
 
     log.debug('Pub/Sub Message received for processing')
 
-    payload = validate_message(message.data, log, ['questionnaireId'])
+    payload = validate_message(message.data, log, ['transactionId', 'questionnaireId'])
     if not payload:
         return  # Failed validation
 
-    questionnaire_id, date_time = payload['questionnaireId'], payload['dateTime']
+    tx_id, questionnaire_id, date_time = payload['transactionId'], payload['questionnaireId'], payload['dateTime']
 
-    log = log.bind(questionnaire_id=questionnaire_id, created=date_time)
+    log = log.bind(questionnaire_id=questionnaire_id, created=date_time, tx_id=tx_id)
 
     receipt_message = {
         'event': {
@@ -178,7 +177,7 @@ def qm_undelivered_mail_to_case(message: Message):
             'source': 'RECEIPT_SERVICE',
             'channel': 'QM',
             'dateTime': date_time,
-            'transactionId': str(uuid.uuid4())
+            'transactionId': tx_id
         },
         'payload': {
             'fulfilmentInformation': {

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -14,8 +14,8 @@ from app.rabbit_helper import send_message_to_rabbitmq
 
 SUBSCRIPTION_NAME = os.getenv("SUBSCRIPTION_NAME", "rm-receipt-subscription")
 OFFLINE_SUBSCRIPTION_NAME = os.getenv("OFFLINE_SUBSCRIPTION_NAME", "rm-offline-receipt-subscription")
-PPO_UNDELIVERED_SUBSCRIPTION_NAME = os.getenv("PPO_UNDELIVERED_SUBSCRIPTION_NAME", "rm-ppo-undelivered-mail-subscription")
-QM_UNDELIVERED_SUBSCRIPTION_NAME = os.getenv("QM_UNDELIVERED_SUBSCRIPTION_NAME", "rm-qm-undelivered-mail-subscription")
+PPO_UNDELIVERED_SUBSCRIPTION_NAME = os.getenv("PPO_UNDELIVERED_SUBSCRIPTION_NAME", "rm-ppo-undelivered-subscription")
+QM_UNDELIVERED_SUBSCRIPTION_NAME = os.getenv("QM_UNDELIVERED_SUBSCRIPTION_NAME", "rm-qm-undelivered-subscription")
 SUBSCRIPTION_PROJECT_ID = os.getenv("SUBSCRIPTION_PROJECT_ID")
 OFFLINE_SUBSCRIPTION_PROJECT_ID = os.getenv("OFFLINE_SUBSCRIPTION_PROJECT_ID")
 PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID = os.getenv("PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,5 @@ services:
     - SUBSCRIPTION_NAME=rm-receipt-subscription
     - OFFLINE_RECEIPT_TOPIC_NAME=offline-receipt-topic
     - OFFLINE_SUBSCRIPTION_NAME=rm-offline-receipt-subscription
+    - PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID=ppo-undelivered-project
+    - QM_UNDELIVERED_SUBSCRIPTION_PROJECT_ID=qm-undelivered-project

--- a/run.py
+++ b/run.py
@@ -8,7 +8,9 @@ from app.app_logging import logger_initial_config
 from app.rabbit_helper import init_rabbitmq
 from app.readiness import Readiness
 from app.subscriber import setup_subscription, OFFLINE_SUBSCRIPTION_NAME, offline_receipt_to_case, \
-    OFFLINE_SUBSCRIPTION_PROJECT_ID
+    OFFLINE_SUBSCRIPTION_PROJECT_ID, PPO_UNDELIVERED_SUBSCRIPTION_NAME, PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID, \
+    ppo_undelivered_mail_to_case, QM_UNDELIVERED_SUBSCRIPTION_NAME, QM_UNDELIVERED_SUBSCRIPTION_PROJECT_ID, \
+    qm_undelivered_mail_to_case
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -23,7 +25,13 @@ def main():
 
     futures = [setup_subscription(),
                setup_subscription(subscription_name=OFFLINE_SUBSCRIPTION_NAME, callback=offline_receipt_to_case,
-                                  subscription_project_id=OFFLINE_SUBSCRIPTION_PROJECT_ID)]
+                                  subscription_project_id=OFFLINE_SUBSCRIPTION_PROJECT_ID),
+               setup_subscription(subscription_name=PPO_UNDELIVERED_SUBSCRIPTION_NAME,
+                                  callback=ppo_undelivered_mail_to_case,
+                                  subscription_project_id=PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID),
+               setup_subscription(subscription_name=QM_UNDELIVERED_SUBSCRIPTION_NAME,
+                                  callback=qm_undelivered_mail_to_case,
+                                  subscription_project_id=QM_UNDELIVERED_SUBSCRIPTION_PROJECT_ID)]
     with Readiness(os.getenv('READINESS_FILE_PATH',
                              os.path.join(os.getcwd(), 'pubsub-ready'))):  # Indicate ready after successful setup
 

--- a/test/component/setup_pubsub.sh
+++ b/test/component/setup_pubsub.sh
@@ -25,10 +25,14 @@ wait_for_curl_success() {
 
 wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/eq-submission-topic" "PUT" "pubsub_emulator topic"
 wait_for_curl_success "http://localhost:8539/v1/projects/offline-project/topics/offline-receipt-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8539/v1/projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8539/v1/projects/qm-undelivered-project/topics/qm-undelivered-mail-topic" "PUT" "pubsub_emulator topic"
 
 echo "Setting up subscriptions to topics..."
 curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
 curl -X PUT http://localhost:8539/v1/projects/offline-project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/offline-project/topics/offline-receipt-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/ppo-undelivered-project/subscriptions/rm-ppo-undelivered-mail-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/qm-undelivered-project/subscriptions/rm-qm-undelivered-mail-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/qm-undelivered-project/topics/qm-undelivered-mail-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:49672/api/aliveness-test/%2F" "GET" "rabbit_mq"
 

--- a/test/component/setup_pubsub.sh
+++ b/test/component/setup_pubsub.sh
@@ -31,8 +31,8 @@ wait_for_curl_success "http://localhost:8539/v1/projects/qm-undelivered-project/
 echo "Setting up subscriptions to topics..."
 curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
 curl -X PUT http://localhost:8539/v1/projects/offline-project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/offline-project/topics/offline-receipt-topic"}'
-curl -X PUT http://localhost:8539/v1/projects/ppo-undelivered-project/subscriptions/rm-ppo-undelivered-mail-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic"}'
-curl -X PUT http://localhost:8539/v1/projects/qm-undelivered-project/subscriptions/rm-qm-undelivered-mail-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/qm-undelivered-project/topics/qm-undelivered-mail-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/ppo-undelivered-project/subscriptions/rm-ppo-undelivered-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/qm-undelivered-project/subscriptions/rm-qm-undelivered-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/qm-undelivered-project/topics/qm-undelivered-mail-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:49672/api/aliveness-test/%2F" "GET" "rabbit_mq"
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -25,6 +25,7 @@ class CensusRMPubSubComponentTest(TestCase):
         self.purge_rabbit_queues()
 
     def test_e2e_with_sucessful_msg(self):
+        self.purge_rabbit_queues()
         expected_case_id = str(uuid.uuid4())
         expected_tx_id = str(uuid.uuid4())
         expected_q_id = str(uuid.uuid4())
@@ -54,6 +55,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert expected_msg == case_msg, "RabbitMQ message text incorrect"
 
     def test_offline_e2e_with_sucessful_msg(self):
+        self.purge_rabbit_queues()
         expected_tx_id = str(uuid.uuid4())
         expected_q_id = str(uuid.uuid4())
         self.publish_offline_to_pubsub(expected_tx_id, expected_q_id)
@@ -81,6 +83,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert expected_msg == case_msg, "RabbitMQ message text incorrect"
 
     def test_e2e_with_no_case_id(self):
+        self.purge_rabbit_queues()
         expected_tx_id = str(uuid.uuid4())
         expected_q_id = str(uuid.uuid4())
         self.publish_to_pubsub(expected_tx_id, expected_q_id)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -24,7 +24,7 @@ class CensusRMPubSubComponentTest(TestCase):
         os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8539"
         self.purge_rabbit_queues()
 
-    def test_e2e_with_sucessful_msg(self):
+    def test_e2e_with_successful_msg(self):
         self.purge_rabbit_queues()
         expected_case_id = str(uuid.uuid4())
         expected_tx_id = str(uuid.uuid4())
@@ -54,7 +54,7 @@ class CensusRMPubSubComponentTest(TestCase):
         case_msg = self.get_msg_body_from_rabbit(RABBIT_TEST_QUEUE)
         assert expected_msg == case_msg, "RabbitMQ message text incorrect"
 
-    def test_offline_e2e_with_sucessful_msg(self):
+    def test_offline_e2e_with_successful_msg(self):
         self.purge_rabbit_queues()
         expected_tx_id = str(uuid.uuid4())
         expected_q_id = str(uuid.uuid4())

--- a/test/component/test_undelivered.py
+++ b/test/component/test_undelivered.py
@@ -1,0 +1,125 @@
+import json
+import time
+import uuid
+from unittest import TestCase
+
+import pika
+from coverage.python import os
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import pubsub_v1
+
+RABBIT_AMQP = "amqp://guest:guest@localhost:35672"
+PPO_UNDELIVERED_TOPIC_PROJECT_ID = "ppo-undelivered-project"
+QM_UNDELIVERED_TOPIC_PROJECT_ID = "qm-undelivered-project"
+RABBIT_EXCHANGE = "events"
+PPO_UNDELIVERED_TOPIC_NAME = "ppo-undelivered-mail-topic"
+QM_UNDELIVERED_TOPIC_NAME = "qm-undelivered-mail-topic"
+UNDELIVERED_RABBIT_TEST_QUEUE = "test.undelivered"
+UNDELIVERED_RABBIT_ROUTE = "event.fulfilment.undelivered"
+
+
+class CensusRMPubSubComponentTest(TestCase):
+
+    def setUp(self):
+        os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8539"
+        self.purge_rabbit_queues()
+
+    def test_ppo_undelivered_e2e_with_sucessful_msg(self):
+        self.purge_rabbit_queues()
+        expected_case_ref = 1234
+        expected_product_code = 'P_OR_H1'
+        self.publish_ppo_undelivered_to_pubsub(expected_case_ref, expected_product_code)
+
+        self.init_rabbitmq(binding_key=UNDELIVERED_RABBIT_ROUTE, queue_name=UNDELIVERED_RABBIT_TEST_QUEUE)
+        assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
+
+        undelivered_msg = self.get_msg_body_from_rabbit(UNDELIVERED_RABBIT_TEST_QUEUE)
+        actual_result = json.loads(undelivered_msg)
+        assert actual_result['event']['type'] == 'UNDELIVERED_MAIL_REPORTED'
+        assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
+        assert actual_result['event']['channel'] == 'PPO'
+        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['payload']['fulfilmentInformation']['caseRef'] == expected_case_ref
+        assert actual_result['payload']['fulfilmentInformation']['productCode'] == expected_product_code
+
+    def test_qm_undelivered_e2e_with_sucessful_msg(self):
+        self.purge_rabbit_queues()
+        expected_q_id = str(uuid.uuid4())
+        self.publish_qm_undelivered_to_pubsub(expected_q_id)
+
+        self.init_rabbitmq(binding_key=UNDELIVERED_RABBIT_ROUTE, queue_name=UNDELIVERED_RABBIT_TEST_QUEUE)
+        assert self.queue_declare_result.method.message_count == 1, "Expected 1 message to be on rabbitmq queue"
+
+        undelivered_msg = self.get_msg_body_from_rabbit(UNDELIVERED_RABBIT_TEST_QUEUE)
+        actual_result = json.loads(undelivered_msg)
+        assert actual_result['event']['type'] == 'UNDELIVERED_MAIL_REPORTED'
+        assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
+        assert actual_result['event']['channel'] == 'QM'
+        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['payload']['fulfilmentInformation']['questionnaireId'] == expected_q_id
+
+    def purge_rabbit_queues(self):
+        self.init_rabbitmq()
+        self.channel.queue_purge(UNDELIVERED_RABBIT_TEST_QUEUE)
+
+    def get_msg_body_from_rabbit(self, rabbit_queue):
+        actual_msg = self.channel.basic_get(rabbit_queue)
+        return actual_msg[2].decode('utf-8')
+
+    def publish_ppo_undelivered_to_pubsub(self, case_ref, product_code):
+        publisher = pubsub_v1.PublisherClient()
+
+        topic_path = publisher.topic_path(PPO_UNDELIVERED_TOPIC_PROJECT_ID, PPO_UNDELIVERED_TOPIC_NAME)
+
+        datadict = {"dateTime": "2019-08-03T14:30:01Z",
+                    "caseRef": case_ref,
+                    "productCode": product_code,
+                    "channel": "PPO",
+                    "type": "UNDELIVERED_MAIL_REPORTED"}
+
+        data = json.dumps(datadict)
+
+        future = publisher.publish(topic_path,
+                                   data=data.encode('utf-8'))
+        if not future.done():
+            time.sleep(1)
+        try:
+            future.result(timeout=30)
+        except GoogleAPIError:
+            assert False, "Failed to publish message to pubsub"
+
+        print(f'Message published to {topic_path}')
+
+    def publish_qm_undelivered_to_pubsub(self, q_id):
+        publisher = pubsub_v1.PublisherClient()
+
+        topic_path = publisher.topic_path(QM_UNDELIVERED_TOPIC_PROJECT_ID, QM_UNDELIVERED_TOPIC_NAME)
+
+        datadict = {"dateTime": "2019-08-03T14:30:01Z",
+                    "questionnaireId": q_id}
+
+        data = json.dumps(datadict)
+
+        future = publisher.publish(topic_path,
+                                   data=data.encode('utf-8'))
+        if not future.done():
+            time.sleep(1)
+        try:
+            future.result(timeout=30)
+        except GoogleAPIError:
+            assert False, "Failed to publish message to pubsub"
+
+        print(f'Message published to {topic_path}')
+
+    def init_rabbitmq(self, rabbitmq_amqp=RABBIT_AMQP,
+                      binding_key=UNDELIVERED_RABBIT_ROUTE,
+                      exchange_name=RABBIT_EXCHANGE,
+                      queue_name=UNDELIVERED_RABBIT_TEST_QUEUE):
+        # NB: instead of pre-loading a definitions.json file we have programmatically declared what we need for the test
+        rabbitmq_connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_amqp))
+        channel = rabbitmq_connection.channel()
+        channel.exchange_declare(exchange=exchange_name, exchange_type='topic', durable=True)
+        queue_declare_result = channel.queue_declare(queue=queue_name, durable=True)
+        channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=binding_key)
+        self.channel = channel
+        self.queue_declare_result = queue_declare_result

--- a/test/component/test_undelivered.py
+++ b/test/component/test_undelivered.py
@@ -39,6 +39,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
         assert actual_result['event']['channel'] == 'PPO'
         assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['event']['transactionId'] == '1'
         assert actual_result['payload']['fulfilmentInformation']['caseRef'] == expected_case_ref
         assert actual_result['payload']['fulfilmentInformation']['productCode'] == expected_product_code
 
@@ -56,6 +57,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
         assert actual_result['event']['channel'] == 'QM'
         assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['event']['transactionId'] == '1'
         assert actual_result['payload']['fulfilmentInformation']['questionnaireId'] == expected_q_id
 
     def purge_rabbit_queues(self):
@@ -71,7 +73,8 @@ class CensusRMPubSubComponentTest(TestCase):
 
         topic_path = publisher.topic_path(PPO_UNDELIVERED_TOPIC_PROJECT_ID, PPO_UNDELIVERED_TOPIC_NAME)
 
-        datadict = {"dateTime": "2019-08-03T14:30:01Z",
+        datadict = {"transactionId": "1",
+                    "dateTime": "2019-08-03T14:30:01Z",
                     "caseRef": case_ref,
                     "productCode": product_code,
                     "channel": "PPO",
@@ -95,7 +98,8 @@ class CensusRMPubSubComponentTest(TestCase):
 
         topic_path = publisher.topic_path(QM_UNDELIVERED_TOPIC_PROJECT_ID, QM_UNDELIVERED_TOPIC_NAME)
 
-        datadict = {"dateTime": "2019-08-03T14:30:01Z",
+        datadict = {"transactionId": "1",
+                    "dateTime": "2019-08-03T14:30:01Z",
                     "questionnaireId": q_id}
 
         data = json.dumps(datadict)

--- a/test/component/test_undelivered.py
+++ b/test/component/test_undelivered.py
@@ -24,7 +24,7 @@ class CensusRMPubSubComponentTest(TestCase):
         os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8539"
         self.purge_rabbit_queues()
 
-    def test_ppo_undelivered_e2e_with_sucessful_msg(self):
+    def test_ppo_undelivered_e2e_with_successful_msg(self):
         self.purge_rabbit_queues()
         expected_case_ref = 1234
         expected_product_code = 'P_OR_H1'
@@ -42,7 +42,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['payload']['fulfilmentInformation']['caseRef'] == expected_case_ref
         assert actual_result['payload']['fulfilmentInformation']['productCode'] == expected_product_code
 
-    def test_qm_undelivered_e2e_with_sucessful_msg(self):
+    def test_qm_undelivered_e2e_with_successful_msg(self):
         self.purge_rabbit_queues()
         expected_q_id = str(uuid.uuid4())
         self.publish_qm_undelivered_to_pubsub(expected_q_id)

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -200,6 +200,37 @@ class TestSubscriber(TestCase):
         mock_message.ack.assert_called_once()
 
     @patch('app.subscriber.send_message_to_rabbitmq')
+    def test_ppo_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
+        mock_message = MagicMock()
+        mock_message.data = json.dumps(
+            {"dateTime": "2019-08-03T14:30:01Z",
+             "caseRef": "123",
+             "productCode": "XYZ",
+             "channel": "PPO",
+             "type": "UNDELIVERED_MAIL_REPORTED"})
+        mock_message.message_id = str(uuid.uuid4())
+
+        from app.subscriber import ppo_undelivered_mail_to_case
+        ppo_undelivered_mail_to_case(mock_message)
+
+        mock_send_message_to_rabbit_mq.assert_called_once()
+        mock_message.ack.assert_called_once()
+
+    @patch('app.subscriber.send_message_to_rabbitmq')
+    def test_qm_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
+        mock_message = MagicMock()
+        mock_message.data = json.dumps(
+            {"dateTime": "2019-08-03T14:30:01Z",
+             "questionnaireId": "123"})
+        mock_message.message_id = str(uuid.uuid4())
+
+        from app.subscriber import qm_undelivered_mail_to_case
+        qm_undelivered_mail_to_case(mock_message)
+
+        mock_send_message_to_rabbit_mq.assert_called_once()
+        mock_message.ack.assert_called_once()
+
+    @patch('app.subscriber.send_message_to_rabbitmq')
     def test_receipt_to_case_missing_eventType(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.message_id = str(uuid.uuid4())

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -214,7 +214,8 @@ class TestSubscriber(TestCase):
     def test_ppo_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"dateTime": self.created,
+            {"transactionId": "1",
+             "dateTime": self.created,
              "caseRef": self.case_ref,
              "productCode": self.product_code,
              "channel": "PPO",
@@ -231,7 +232,8 @@ class TestSubscriber(TestCase):
             'product_code': self.product_code,
             'subscription_name': self.ppo_undelivered_subscription_name,
             'subscription_project': self.ppo_undelivered_subscription_project_id,
-            'message_id': mock_message.message_id
+            'message_id': mock_message.message_id,
+            'tx_id': '1'
         }
 
         expected_rabbit_message = json.dumps(
@@ -240,7 +242,7 @@ class TestSubscriber(TestCase):
                 'source': 'RECEIPT_SERVICE',
                 'channel': 'PPO',
                 'dateTime': '2008-08-24T00:00:00Z',
-                'transactionId': '12345'
+                'transactionId': '1'
             },
                 'payload': {
                     'fulfilmentInformation': {
@@ -250,10 +252,8 @@ class TestSubscriber(TestCase):
                 }
             })
         from app.subscriber import ppo_undelivered_mail_to_case
-        with patch('uuid.uuid4') as mock_uuid:
-            with self.checkExpectedLogLine('DEBUG', expected_log_event, expected_log_kwargs):
-                mock_uuid.return_value = '12345'
-                ppo_undelivered_mail_to_case(mock_message)
+        with self.checkExpectedLogLine('DEBUG', expected_log_event, expected_log_kwargs):
+            ppo_undelivered_mail_to_case(mock_message)
 
         mock_send_message_to_rabbit_mq.assert_called_once_with(expected_rabbit_message,
                                                                routing_key='event.fulfilment.undelivered')
@@ -263,7 +263,8 @@ class TestSubscriber(TestCase):
     def test_qm_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"dateTime": self.created,
+            {"transactionId": "1",
+             "dateTime": self.created,
              "questionnaireId": self.questionnaire_id})
         mock_message.message_id = str(uuid.uuid4())
 
@@ -275,7 +276,8 @@ class TestSubscriber(TestCase):
             'created': self.created,
             'subscription_name': self.qm_undelivered_subscription_name,
             'subscription_project': self.qm_undelivered_subscription_project_id,
-            'message_id': mock_message.message_id
+            'message_id': mock_message.message_id,
+            'tx_id': '1'
         }
 
         expected_rabbit_message = json.dumps({
@@ -284,7 +286,7 @@ class TestSubscriber(TestCase):
                 'source': 'RECEIPT_SERVICE',
                 'channel': 'QM',
                 'dateTime': '2008-08-24T00:00:00Z',
-                'transactionId': '12345'
+                'transactionId': '1'
             },
             'payload': {
                 'fulfilmentInformation': {

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -13,6 +13,12 @@ class TestSubscriber(TestCase):
     offline_subscription_name = 'test-offline-subscription'
     subscription_project_id = 'test-project-id'
     offline_subscription_project_id = 'test-offline-project-id'
+    ppo_undelivered_subscription_name = 'test_ppo_undelivered_subscription'
+    ppo_undelivered_subscription_project_id = 'test-ppo-undelivered-project-id'
+    qm_undelivered_subscription_name = 'test_qm_undelivered_subscription'
+    qm_undelivered_subscription_project_id = 'test-qm-undelivered-project-id'
+    case_ref = 12345
+    product_code = 'XYZ'
     case_id = 'e079cea4-1447-4529-aa70-8757f1806f60'
     questionnaire_id = '0120000000001000'
     created = '2008-08-24T00:00:00Z'
@@ -83,7 +89,11 @@ class TestSubscriber(TestCase):
             'SUBSCRIPTION_NAME': self.subscription_name,
             'OFFLINE_SUBSCRIPTION_NAME': self.offline_subscription_name,
             'SUBSCRIPTION_PROJECT_ID': self.subscription_project_id,
-            'OFFLINE_SUBSCRIPTION_PROJECT_ID': self.offline_subscription_project_id
+            'OFFLINE_SUBSCRIPTION_PROJECT_ID': self.offline_subscription_project_id,
+            'PPO_UNDELIVERED_SUBSCRIPTION_NAME': self.ppo_undelivered_subscription_name,
+            'PPO_UNDELIVERED_SUBSCRIPTION_PROJECT_ID': self.ppo_undelivered_subscription_project_id,
+            'QM_UNDELIVERED_SUBSCRIPTION_NAME': self.qm_undelivered_subscription_name,
+            'QM_UNDELIVERED_SUBSCRIPTION_PROJECT_ID': self.qm_undelivered_subscription_project_id
         }
         os.environ.update(test_environment_variables)
 
@@ -159,7 +169,8 @@ class TestSubscriber(TestCase):
     def test_offline_receipt_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"transactionId": "1", "questionnaireId": self.questionnaire_id, "dateTime": self.created, "channel": "PQRS"})
+            {"transactionId": "1", "questionnaireId": self.questionnaire_id, "dateTime": self.created,
+             "channel": "PQRS"})
         mock_message.message_id = str(uuid.uuid4())
 
         create_stub_function(self.created, return_value=self.parsed_created)
@@ -203,31 +214,92 @@ class TestSubscriber(TestCase):
     def test_ppo_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"dateTime": "2019-08-03T14:30:01Z",
-             "caseRef": "123",
-             "productCode": "XYZ",
+            {"dateTime": self.created,
+             "caseRef": self.case_ref,
+             "productCode": self.product_code,
              "channel": "PPO",
              "type": "UNDELIVERED_MAIL_REPORTED"})
+
         mock_message.message_id = str(uuid.uuid4())
 
-        from app.subscriber import ppo_undelivered_mail_to_case
-        ppo_undelivered_mail_to_case(mock_message)
+        create_stub_function(self.created, return_value=self.parsed_created)
 
-        mock_send_message_to_rabbit_mq.assert_called_once()
+        expected_log_event = 'Message processing complete'
+        expected_log_kwargs = {
+            'case_ref': self.case_ref,
+            'created': self.created,
+            'product_code': self.product_code,
+            'subscription_name': self.ppo_undelivered_subscription_name,
+            'subscription_project': self.ppo_undelivered_subscription_project_id,
+            'message_id': mock_message.message_id
+        }
+
+        expected_rabbit_message = json.dumps(
+            {'event': {
+                'type': 'UNDELIVERED_MAIL_REPORTED',
+                'source': 'RECEIPT_SERVICE',
+                'channel': 'PPO',
+                'dateTime': '2008-08-24T00:00:00Z',
+                'transactionId': '12345'
+            },
+                'payload': {
+                    'fulfilmentInformation': {
+                        'caseRef': self.case_ref,
+                        'productCode': self.product_code
+                    }
+                }
+            })
+        from app.subscriber import ppo_undelivered_mail_to_case
+        with patch('uuid.uuid4') as mock_uuid:
+            with self.checkExpectedLogLine('DEBUG', expected_log_event, expected_log_kwargs):
+                mock_uuid.return_value = '12345'
+                ppo_undelivered_mail_to_case(mock_message)
+
+        mock_send_message_to_rabbit_mq.assert_called_once_with(expected_rabbit_message,
+                                                               routing_key='event.fulfilment.undelivered')
         mock_message.ack.assert_called_once()
 
     @patch('app.subscriber.send_message_to_rabbitmq')
     def test_qm_undelivered_mail_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"dateTime": "2019-08-03T14:30:01Z",
-             "questionnaireId": "123"})
+            {"dateTime": self.created,
+             "questionnaireId": self.questionnaire_id})
         mock_message.message_id = str(uuid.uuid4())
 
-        from app.subscriber import qm_undelivered_mail_to_case
-        qm_undelivered_mail_to_case(mock_message)
+        create_stub_function(self.created, return_value=self.parsed_created)
 
-        mock_send_message_to_rabbit_mq.assert_called_once()
+        expected_log_event = 'Message processing complete'
+        expected_log_kwargs = {
+            'questionnaire_id': self.questionnaire_id,
+            'created': self.created,
+            'subscription_name': self.qm_undelivered_subscription_name,
+            'subscription_project': self.qm_undelivered_subscription_project_id,
+            'message_id': mock_message.message_id
+        }
+
+        expected_rabbit_message = json.dumps({
+            'event': {
+                'type': 'UNDELIVERED_MAIL_REPORTED',
+                'source': 'RECEIPT_SERVICE',
+                'channel': 'QM',
+                'dateTime': '2008-08-24T00:00:00Z',
+                'transactionId': '12345'
+            },
+            'payload': {
+                'fulfilmentInformation': {
+                    'questionnaireId': self.questionnaire_id
+                }
+            }
+        })
+        from app.subscriber import qm_undelivered_mail_to_case
+        with patch('uuid.uuid4') as mock_uuid:
+            with self.checkExpectedLogLine('DEBUG', expected_log_event, expected_log_kwargs):
+                mock_uuid.return_value = '12345'
+                qm_undelivered_mail_to_case(mock_message)
+
+        mock_send_message_to_rabbit_mq.assert_called_once_with(expected_rabbit_message,
+                                                               routing_key='event.fulfilment.undelivered')
         mock_message.ack.assert_called_once()
 
     @patch('app.subscriber.send_message_to_rabbitmq')


### PR DESCRIPTION
# Motivation and Context
QM (Leidos) and PPO (Royal Mail) will receive email that is undeliverable - undelivered as addressed - and they will notify RM. We need to send a message to Field so that the cases can be followed up and we can find out why the mail couldn't be delivered.

# What has changed
Subscribes to two new pubsub topics: one for QM and one for PPO. Transforms the messages into the RM format and publishes onto Rabbit.

# How to test?
Run the acceptance tests, along with Action Scheduler, Case API, Case Processor on the same branch (`undelivered-as-addressed`) along with census-rm-docker-dev.

# Links
Trello: https://trello.com/c/HOWUDNMR