### PR TITLE
Allow dates in format YYYY-mm-DDTHH:MM:SS, assume UTC timezone

### DIFF
--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -87,7 +87,7 @@ def offline_receipt_to_case(message: Message):
 
     log.info('Pub/Sub Message received for processing')
 
-    payload = validate_message(message.data, log, ['transactionId', 'questionnaireId', 'channel'])
+    payload = validate_message(message.data, log, ['transactionId', 'questionnaireId', 'channel'], expect_iso_format_datetime=False)
     if not payload:
         return  # Failed validation
 
@@ -125,7 +125,7 @@ def ppo_undelivered_mail_to_case(message: Message):
 
     log.debug('Pub/Sub Message received for processing')
 
-    payload = validate_message(message.data, log, ['transactionId', 'caseRef', 'productCode'])
+    payload = validate_message(message.data, log, ['transactionId', 'caseRef', 'productCode'], expect_iso_format_datetime=False)
     if not payload:
         return  # Failed validation
 
@@ -163,7 +163,7 @@ def qm_undelivered_mail_to_case(message: Message):
 
     log.debug('Pub/Sub Message received for processing')
 
-    payload = validate_message(message.data, log, ['transactionId', 'questionnaireId'])
+    payload = validate_message(message.data, log, ['transactionId', 'questionnaireId'], expect_iso_format_datetime=False)
     if not payload:
         return  # Failed validation
 
@@ -193,16 +193,16 @@ def qm_undelivered_mail_to_case(message: Message):
     log.debug('Message processing complete')
 
 
-def validate_message(message_data, log, expected_keys, date_time_key='dateTime'):
+def validate_message(message_data, log, expected_keys, date_time_key='dateTime', expect_iso_format_datetime=True):
     try:
         payload = json.loads(message_data)  # parse metadata as JSON payload
         for expected_key in expected_keys:
             if expected_key not in payload:
                 log.error('Pub/Sub Message missing required data', missing_json_key=expected_key)
 
-        try:
+        if expect_iso_format_datetime:
             parse_datetime(payload[date_time_key]).isoformat()
-        except ValueError:
+        else:
             datetime.strptime(payload[date_time_key], '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc).isoformat()
 
         return payload

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -156,7 +156,7 @@ class CensusRMPubSubComponentTest(TestCase):
 
         topic_path = publisher.topic_path(OFFLINE_RECEIPT_TOPIC_PROJECT_ID, OFFLINE_RECEIPT_TOPIC_NAME)
 
-        datadict = {"dateTime": "2008-08-24T00:00:00Z", "productCode": "H1", "channel": "PQRS",
+        datadict = {"dateTime": "2008-08-24T00:00:00", "productCode": "H1", "channel": "PQRS",
                     "questionnaireId": questionnaire_id,
                     "source": "RECEIPT-SERVICE", "type": "FULFILMENT_CONFIRMED",
                     "transactionId": tx_id}

--- a/test/component/test_undelivered.py
+++ b/test/component/test_undelivered.py
@@ -38,7 +38,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['event']['type'] == 'UNDELIVERED_MAIL_REPORTED'
         assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
         assert actual_result['event']['channel'] == 'PPO'
-        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01+00:00'
         assert actual_result['event']['transactionId'] == '1'
         assert actual_result['payload']['fulfilmentInformation']['caseRef'] == expected_case_ref
         assert actual_result['payload']['fulfilmentInformation']['productCode'] == expected_product_code
@@ -56,7 +56,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['event']['type'] == 'UNDELIVERED_MAIL_REPORTED'
         assert actual_result['event']['source'] == 'RECEIPT_SERVICE'
         assert actual_result['event']['channel'] == 'QM'
-        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01Z'
+        assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01+00:00'
         assert actual_result['event']['transactionId'] == '1'
         assert actual_result['payload']['fulfilmentInformation']['questionnaireId'] == expected_q_id
 
@@ -74,7 +74,7 @@ class CensusRMPubSubComponentTest(TestCase):
         topic_path = publisher.topic_path(PPO_UNDELIVERED_TOPIC_PROJECT_ID, PPO_UNDELIVERED_TOPIC_NAME)
 
         datadict = {"transactionId": "1",
-                    "dateTime": "2019-08-03T14:30:01Z",
+                    "dateTime": "2019-08-03T14:30:01",
                     "caseRef": case_ref,
                     "productCode": product_code,
                     "channel": "PPO",
@@ -99,7 +99,7 @@ class CensusRMPubSubComponentTest(TestCase):
         topic_path = publisher.topic_path(QM_UNDELIVERED_TOPIC_PROJECT_ID, QM_UNDELIVERED_TOPIC_NAME)
 
         datadict = {"transactionId": "1",
-                    "dateTime": "2019-08-03T14:30:01Z",
+                    "dateTime": "2019-08-03T14:30:01",
                     "questionnaireId": q_id}
 
         data = json.dumps(datadict)

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -23,6 +23,8 @@ class TestSubscriber(TestCase):
     questionnaire_id = '0120000000001000'
     created = '2008-08-24T00:00:00Z'
     parsed_created = '2008-08-24T00:00:00+00:00'
+    created_offline_spec = '2008-08-24T00:00:00'
+    parsed_created_offline_spec = '2008-08-24T00:00:00+00:00'
     gcp_bucket = 'test-bucket'
     gcp_object_id = 'test-object'
     subscriber_future = 'test-future'
@@ -125,8 +127,6 @@ class TestSubscriber(TestCase):
              "timeCreated": self.created})
         mock_message.message_id = str(uuid.uuid4())
 
-        create_stub_function(self.created, return_value=self.parsed_created)
-
         expected_log_event = 'Message processing complete'
         expected_log_kwargs = {
             'bucket_name': self.gcp_bucket,
@@ -169,16 +169,14 @@ class TestSubscriber(TestCase):
     def test_offline_receipt_to_case(self, mock_send_message_to_rabbit_mq):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
-            {"transactionId": "1", "questionnaireId": self.questionnaire_id, "dateTime": self.created,
+            {"transactionId": "1", "questionnaireId": self.questionnaire_id, "dateTime": self.created_offline_spec,
              "channel": "PQRS"})
         mock_message.message_id = str(uuid.uuid4())
-
-        create_stub_function(self.created, return_value=self.parsed_created)
 
         expected_log_event = 'Message processing complete'
         expected_log_kwargs = {
             'questionnaire_id': self.questionnaire_id,
-            'created': self.parsed_created,
+            'created': self.parsed_created_offline_spec,
             'tx_id': '1',
             'channel': 'PQRS',
             'subscription_name': self.offline_subscription_name,
@@ -215,7 +213,7 @@ class TestSubscriber(TestCase):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
             {"transactionId": "1",
-             "dateTime": self.created,
+             "dateTime": self.created_offline_spec,
              "caseRef": self.case_ref,
              "productCode": self.product_code,
              "channel": "PPO",
@@ -223,12 +221,10 @@ class TestSubscriber(TestCase):
 
         mock_message.message_id = str(uuid.uuid4())
 
-        create_stub_function(self.created, return_value=self.parsed_created)
-
         expected_log_event = 'Message processing complete'
         expected_log_kwargs = {
             'case_ref': self.case_ref,
-            'created': self.created,
+            'created': self.parsed_created_offline_spec,
             'product_code': self.product_code,
             'subscription_name': self.ppo_undelivered_subscription_name,
             'subscription_project': self.ppo_undelivered_subscription_project_id,
@@ -241,7 +237,7 @@ class TestSubscriber(TestCase):
                 'type': 'UNDELIVERED_MAIL_REPORTED',
                 'source': 'RECEIPT_SERVICE',
                 'channel': 'PPO',
-                'dateTime': '2008-08-24T00:00:00Z',
+                'dateTime': '2008-08-24T00:00:00+00:00',
                 'transactionId': '1'
             },
                 'payload': {
@@ -264,16 +260,16 @@ class TestSubscriber(TestCase):
         mock_message = MagicMock()
         mock_message.data = json.dumps(
             {"transactionId": "1",
-             "dateTime": self.created,
+             "dateTime": self.created_offline_spec,
              "questionnaireId": self.questionnaire_id})
         mock_message.message_id = str(uuid.uuid4())
 
-        create_stub_function(self.created, return_value=self.parsed_created)
+        create_stub_function(self.created, return_value=self.parsed_created_offline_spec)
 
         expected_log_event = 'Message processing complete'
         expected_log_kwargs = {
             'questionnaire_id': self.questionnaire_id,
-            'created': self.created,
+            'created': self.parsed_created_offline_spec,
             'subscription_name': self.qm_undelivered_subscription_name,
             'subscription_project': self.qm_undelivered_subscription_project_id,
             'message_id': mock_message.message_id,
@@ -285,7 +281,7 @@ class TestSubscriber(TestCase):
                 'type': 'UNDELIVERED_MAIL_REPORTED',
                 'source': 'RECEIPT_SERVICE',
                 'channel': 'QM',
-                'dateTime': '2008-08-24T00:00:00Z',
+                'dateTime': '2008-08-24T00:00:00+00:00',
                 'transactionId': '1'
             },
             'payload': {
@@ -542,7 +538,7 @@ class TestSubscriber(TestCase):
         mock_message.data = json.dumps(
             {"metadata": {"tx_id": "1", "questionnaire_id": "0120000000001000"}, "timeCreated": "123"})
 
-        expected_log_event = 'Pub/Sub Message has invalid RFC 3339 timeCreated datetime string'
+        expected_log_event = 'Pub/Sub Message has invalid datetime string'
         expected_log_kwargs = {
             'bucket_name': self.gcp_bucket,
             'object_name': self.gcp_object_id,


### PR DESCRIPTION
## Motivation and Context
The suppliers will be sending us datetimes in the format `YYYY-mm-DDTHH:MM:SS`, census-rm-pubsub needs to convert these to a timezoned ISO format so that the downstream RM services can deserialise it. 

## What has changed
* Allow dates in format YYYY-mm-DDTHH:MM:SS, assume UTC timezone
* Update tests for all offline inbound channels to send in this format

## How to test?
Run with the linked acceptance tests branch.

## Links
https://trello.com/c/vo5OZr7z/1120-pubsub-receipting-service-needs-to-handle-timestamps-without-timezone
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/131