### PR TITLE
send msg to rabbitmq with Persistence on

### DIFF
--- a/app/rabbit_helper.py
+++ b/app/rabbit_helper.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import pika
+from pika.spec import PERSISTENT_DELIVERY_MODE
 from structlog import wrap_logger
 
 RABBIT_EXCHANGE = os.getenv("RABBIT_EXCHANGE", "events")
@@ -39,12 +40,15 @@ def send_message_to_rabbitmq(message,
     :return: boolean
     :raises: PublishMessageError
     """
+    properties = pika.BasicProperties(content_type='application/json', delivery_mode=PERSISTENT_DELIVERY_MODE)
+
     rabbitmq_connection = _create_connection()
     rabbitmq_channel = rabbitmq_connection.channel()
     rabbitmq_channel.basic_publish(exchange=exchange_name,
                                    routing_key=routing_key,
                                    body=str(message),
-                                   properties=pika.BasicProperties(content_type='application/json'))
+                                   properties=properties)
+
     logger.info('Message successfully sent to rabbitmq', exchange=exchange_name, route=routing_key)
 
     rabbitmq_connection.close()

--- a/test/unit/test_rabbit_helper.py
+++ b/test/unit/test_rabbit_helper.py
@@ -9,7 +9,6 @@ from test import create_stub_function
 
 
 class RabbitHelperTestCase(TestCase):
-
     rabbit_username = 'user'
     rabbit_password = 'pa55word'
     rabbit_host = 'host'
@@ -69,8 +68,9 @@ class RabbitHelperTestCase(TestCase):
 
             channel_mock = MagicMock()
             connection_mock.channel = create_stub_function(return_value=channel_mock)
-            mock_pika.BasicProperties = create_stub_function(expected_kwargs={'content_type': 'application/json'},
-                                                             return_value=self.property_class)
+            mock_pika.BasicProperties = \
+                create_stub_function(expected_kwargs={'content_type': 'application/json', 'delivery_mode': 2},
+                                     return_value=self.property_class)
 
             send_message_to_rabbitmq(self.message,
                                      exchange_name=self.rabbit_exchange,


### PR DESCRIPTION
## Motivation and Context
Pubsub doesn't send msgs

## What has changed
Published msgs are now sent with persistence 

## How to test?
Run the tests for pubsub and ATs.

Then to check the persistence:
Disable case-processor, stick a valid receipting message on gcp pubsub, check that the msg published to case.Responses is persistent.  We're already happy that restarting rabbit etc persists the msgs once they're marked as persistent. 

For testing this easily with this pubsub branch I built an otherwise master docker-dev locally.  Ran a receipting AT test in debug mode, with a breakpoint on publish to GCP.  At this point disable caseprocessor (docker stop caseprocessor), then let the tests run on (they'll fail, but that's expected here) - manually check you rabbitmq case.Responses queue has a msg on it with persistence.


## Links
https://trello.com/c/iMCTeCgt/1333-investigate-fix-python-apps-persistence-writing-to-delay-or-quarantine