### PR TITLE
Rmc 173 blank questionnaire returned

### DIFF
--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -87,12 +87,12 @@ def offline_receipt_to_case(message: Message):
     log.info('Pub/Sub Message received for processing')
 
     payload = validate_offline_receipt(message.data, log, ['transactionId', 'questionnaireId', 'channel'])
+    if not payload:
+        return  # Failed validation
     try:
         unreceipt = payload['unreceipt']
     except KeyError:
         unreceipt = False
-    if not payload:
-        return  # Failed validation
 
     tx_id, questionnaire_id, channel = payload['transactionId'], payload['questionnaireId'], payload['channel']
     time_obj_created = datetime.strptime(payload['dateTime'], '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc).isoformat()

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -89,10 +89,8 @@ def offline_receipt_to_case(message: Message):
     payload = validate_offline_receipt(message.data, log, ['transactionId', 'questionnaireId', 'channel'])
     if not payload:
         return  # Failed validation
-    try:
-        unreceipt = payload['unreceipt']
-    except KeyError:
-        unreceipt = False
+
+    unreceipt = payload.get('unreceipt', False)
 
     tx_id, questionnaire_id, channel = payload['transactionId'], payload['questionnaireId'], payload['channel']
     time_obj_created = datetime.strptime(payload['dateTime'], '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc).isoformat()

--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -87,6 +87,10 @@ def offline_receipt_to_case(message: Message):
     log.info('Pub/Sub Message received for processing')
 
     payload = validate_offline_receipt(message.data, log, ['transactionId', 'questionnaireId', 'channel'])
+    try:
+        unreceipt = payload['unreceipt']
+    except KeyError:
+        unreceipt = False
     if not payload:
         return  # Failed validation
 
@@ -106,7 +110,7 @@ def offline_receipt_to_case(message: Message):
         'payload': {
             'response': {
                 'questionnaireId': questionnaire_id,
-                'unreceipt': False
+                'unreceipt': unreceipt
             }
         }
     }


### PR DESCRIPTION
## Motivation and Context
For the upcoming Blank Questionnaire changes, pubsub needs to be able to check if the unreceipt key sent with the message that is emitted. I've added a check to use it if it's there or just default to False
## What has changed
- Added unreceipt to the offline_receipt to Case processor
## How to test?
- Run tests
- Run with other prs and ATs

## Links
[Trello](https://trello.com/c/EmrziSj3)
