### PR TITLE
Making Dockerfile Use Non-root User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.6-slim
 
-WORKDIR /app
-COPY . /app
+RUN pip3 install pipenv
 
-RUN pip3 install pipenv && pipenv install --deploy --system
-
+RUN groupadd --gid 1000 pubsub && useradd --create-home --system --uid 1000 --gid pubsub pubsub
+WORKDIR /home/pubsub
 CMD ["python3", "run.py"]
+
+COPY Pipfile* /home/pubsub/
+RUN pipenv install --deploy --system
+USER pubsub
+
+COPY --chown=pubsub . /home/pubsub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - rabbitmq
     restart: always
     healthcheck:
-      test: bash -c "[ -f /app/pubsub-ready ]"
+      test: bash -c "[ -f /home/pubsub/pubsub-ready ]"
       interval: 5s
     environment:
     - RABBIT_HOST=rabbitmq


### PR DESCRIPTION
# Motivation and Context
Changing the Dockerfile to use non-root user rather than root which makes it more secure (someone could gain root access to the Docker host by hacking the application running inside the container)

# What has changed
Created new user in Dockerfile and assigned permission levels. Also optimised the order in which the image is built

# How to test? 
Clone and build the new Docker image and test it locally and in GCP. Run ATs against new image making sure to have applied changes from Kubernetes repo

# Links
https://trello.com/c/Pd48zUsd
