### PR TITLE
Rename productCode to fulfilmentCode

### DIFF
--- a/app/subscriber.py
+++ b/app/subscriber.py
@@ -144,7 +144,7 @@ def ppo_undelivered_mail_to_case(message: Message):
         'payload': {
             'fulfilmentInformation': {
                 'caseRef': case_ref,
-                'productCode': product_code
+                'fulfilmentCode': product_code
             }
         }
     }

--- a/test/component/test_undelivered.py
+++ b/test/component/test_undelivered.py
@@ -41,7 +41,7 @@ class CensusRMPubSubComponentTest(TestCase):
         assert actual_result['event']['dateTime'] == '2019-08-03T14:30:01+00:00'
         assert actual_result['event']['transactionId'] == '1'
         assert actual_result['payload']['fulfilmentInformation']['caseRef'] == expected_case_ref
-        assert actual_result['payload']['fulfilmentInformation']['productCode'] == expected_product_code
+        assert actual_result['payload']['fulfilmentInformation']['fulfilmentCode'] == expected_product_code
 
     def test_qm_undelivered_e2e_with_successful_msg(self):
         self.purge_rabbit_queues()

--- a/test/unit/test_subscriber.py
+++ b/test/unit/test_subscriber.py
@@ -286,7 +286,7 @@ class TestSubscriber(TestCase):
                 'payload': {
                     'fulfilmentInformation': {
                         'caseRef': self.case_ref,
-                        'productCode': self.product_code
+                        'fulfilmentCode': self.product_code
                     }
                 }
             })


### PR DESCRIPTION
## Motivation and Context
Event dictionary changed an RM-interrnal event for undelivered mail.

## What has changed
Renamed productCode to fulfilmentCode

## How to test?
Play an undelivered mail scenario and check the logged payload in the event contains the fulfilment code.

## Links
Trello: https://trello.com/c/1kGNz8vl